### PR TITLE
Implement the entire SCRAM protocol in one helper library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,25 @@
 language: erlang
+
 dist: bionic
+
 branches:
     only:
         - master
+
 otp_release:
-    - 23.0.1
+    - 23.0
     - 22.3
-    - 21.1
+    - 21.2
+
 install:
-    - rebar3 get-deps
+    - make
+    - make test-compile
+    - travis_retry pip install --user codecov
+
 script:
-    - rebar3 as test ct
-    - rebar3 dialyzer
+    - make test
+    - make dialyzer
+
+after_success:
+    - make codecov
+    - codecov

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: rel deps test
+
+all: deps compile
+
+compile: rebar3
+	./rebar3 compile
+
+deps: rebar3
+	./rebar3 get-deps
+
+clean: rebar3
+	./rebar3 clean
+
+test-deps: rebar3
+	./rebar3 get-deps
+
+test-compile: rebar3 test-deps
+	./rebar3 compile
+
+test: test-compile
+	./rebar3 ct
+
+codecov: _build/test/cover/ct.coverdata
+	./rebar3 as test codecov analyze
+
+rebar3:
+	wget https://github.com/erlang/rebar3/releases/download/3.13.2/rebar3 &&\
+	chmod u+x rebar3
+
+dialyzer: rebar3
+	./rebar3 dialyzer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-fast_scram
-=====
+# Fast SCRAM
+
+[![Build Status](https://travis-ci.com/esl/fast_scram.svg?branch=master)](https://travis-ci.org/esl/fast_scram)
+[![codecov](https://codecov.io/gh/esl/fast_scram/branch/master/graph/badge.svg)](https://codecov.io/gh/esl/fast_scram)
 
 `fast_scram` is an Erlang implementation of the _Salted Challenge Response Authentication Mechanism_,
 where the challenge algorithm is a carefully-optimised NIF, while respecting the latency properties
@@ -36,6 +38,167 @@ where `Hash` is the underlying hash function chosen as described by
 -type sha_type() :: crypto:sha1() | crypto:sha2().
 ```
 
+### Full algorithm
+If you want to avoid reimplementing SCRAM again and again, you can use the extended API.
+The best example is that one of the tests. Given already configured states, the flow is as follows:
+```erlang
+    %% AUTH
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    %% CHALLENGE
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    %% RESPONSE
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    %% SUCCESS
+    {ok, ServerFinal, ServerFinalState} = fast_scram:mech_step(ServerState4, ClientFinal),
+    %% Client successfully accepts the server's verifier
+    {ok, ClientFinal, ClientFinalState} = fast_scram:mech_step(ClientState5, ServerFinal).
+```
+
+The API is simple: `fast_scram:mech_step/2` takes a SCRAM state, and the last message it received
+(in the case of the first step of the client, this is obviously, and necessarily, empty).
+
+The return value is always a 3-tuple, tagged with either `ok`, `continue` or `error`.
+The second element is always a binary, and the third is always the scram state.
+```erlang
+-spec mech_step(fast_scram_state(), binary()) ->
+    {ok,       final_message(), fast_scram_state()} |
+    {continue, next_message(),  fast_scram_state()} |
+    {error,    error_message(), fast_scram_state()}.
+```
+
+* `ok` tagged-tuples mean that the algorithm has returned successfully.
+  The message will be the last one to send to the peer,
+  empty in the case of the client, containing the server verifier for the server.
+  The state will not be needed anymore, so it can be ignored.
+* `continue` means that the algorithm is not done yet. The message is what needs to be send to the
+  peer, by whatever means the protocol chooses (encoded in a major packet through some network
+  protocol, etc). The new state is the one that should be plugged into the next step,
+  when the peer has answered.
+* `error` means that the algorithm is over, unsuccessfully, where the message contains some
+  explanation. The state might include parsed data or be return as it was.
+
+How messages are delivered to peers is part of the protocol within which SCRAM is embedded:
+for example, in XMPP, messages are delivered as special stanzas with the SCRAM payload encoded in
+`base64`. So an XMPP client would do, for example, using [exml][exml]
+```erlang
+    {continue, Message, NewState} = fast_scram:mech_step(State, <<>>),
+    Contents = #xmlcdata{content = base64:encode(Message)},
+    Stanza = #xmlel{name = <<"auth">>,
+                    attrs = [{<<"xmlns">>, <<"urn:ietf:params:xml:ns:xmpp-sasl">>},
+                             {<<"mechanism">>, <<"SCRAM-SHA-1">>}],
+                    children = [Contents]},
+    %% send stanza
+```
+
+### Configuration
+This is the part that requires some knowledge of the SCRAM protocol.
+A ready SCRAM state is built using `fast_scram:mech_new/1`,
+which takes a map with the configuration parameters.
+
+Example configurations are, for the client:
+```erlang
+    #{entity => client,
+      hash_method => sha,
+      username => <<"user">>,
+      auth_data => #{password => <<"somesupersafepassword">>}}
+```
+
+And for a server:
+```erlang
+    #{entity => server,
+      hash_method => sha,
+      nonce => <<"3rfcNHYJY1ZVvWVs7j">>,
+      retrieve_mechanism => fun(Username) -> MoreConfig end}
+```
+
+The first and most important key is the `entity` key,
+which takes two values: `client` or `server`.
+The next necessary key is the negotiated `hash_method`,
+that is, which of the `SHA` algorithms will be executed.
+Can be any of the OTP's `crypto:sha1() | crypto:sha2()`.
+
+Next keys depend on the chosen entity.
+If you want to configure a `client` state, then a `username` key is required.
+If you want to configure a `server` state, then `retrieve_mechanism` is required.
+
+Next, for both cases, an `auth_data` key is required. The value for this key is a map containing the
+minimum necessary information for executing a SCRAM algorithm: often just a `password`.
+But often, to avoid the challenge penalty, servers and client cache certain keys,
+considering that a server often gives the same salt and iteration count for a specific client.
+So we can instead cache `salted_password`, or a pair `stored_key`-`server_key`,
+or a pair `client_key`-`server_key`. All these pairs can be given with a `password` as a fallback,
+if the algorithm was to need recalculation.
+
+If the client is being given any cached configuration, it will simply attempt that data regardless
+of the challenge that the server requests from him. If verification was desired instead of failing,
+the main config map can take keys `cached_it_count` and `cached_salt`, and these will be verified
+against the challenge requested by the server: if it matches, the cached data will be used. If it
+doesn't, all data will be recalculated using the `password` key in the `auth_data` map, provided it
+is available.
+
+Channel binding specification can also be given by `channel_binding => {Type, Data}`,
+where `Type` is the channel binding name, and `Data` is its associated payload.
+The default is `{undefined, <<>>}`, which will set the gs2 flag to no binding, that is, `<<"n">>`.
+If for example a client had channel binding, but saw the server no offering any,
+this client should set the flag to `{none, <<>>}`: this will send the gs2 flag as `<<"y">>`.
+
+### Server retrieval of the client's data
+
+SCRAM requires that the server retrieves the user's data with the username as exactly given
+in the client's first message. To configure this, a `retrieve_mechanism` key is required,
+whose value is a function of the type:
+
+```erlang
+-type retrieve_mechanism() :: fun((username()) -> configuration())
+                            | fun((username(), fast_scram_state()) ->
+                                    {configuration(), fast_scram_state()}).
+```
+
+That is, a function object that:
+* Takes a username and returns more configuration to append to the state
+* Takes a username and the current state, and returns a pair of the extended
+configuration and a possibly new state.
+
+See examples below.
+
+#### `fun((username()) -> configuration())`
+
+```erlang
+    Fun = fun(Username) ->
+              %% Get scram data for this user from the database
+              ...
+              %%% {StoredKey, ServerKey, Salt, ItCount} ->
+              ...
+              #{salt => Salt,
+                it_count => ItCount,
+                auth_data => #{stored_key => StoredKey,
+                               server_key => ServerKey}}
+          end,
+    {ok, State} = fast_scram:mech_new(
+                        #{entity => server, hash_method => Sha, retrieve_mechanism => Fun}).
+```
+
+#### `fun((username(), fast_scram_state()) -> {configuration(), fast_scram_state()}).`
+
+```erlang
+    Fun = fun(Username, State0) ->
+              %% Get scram data for this user from the database
+              ...
+              %%% {StoredKey, ServerKey, Salt, ItCount} ->
+              ...
+              Config = #{salt => Salt,
+                        it_count => ItCount,
+                        auth_data => #{
+                            stored_key => StoredKey,
+                            server_key => ServerKey}}
+
+              %% Custom data can also be stored in the state to be extracted later
+              State1 = fast_scram:mech_set(some_key, SomeData, State0),
+              {Config, State1}
+          end,
+    {ok, State} = fast_scram:mech_new(
+                        #{entity => server, hash_method => Sha, retrieve_mechanism => Fun}).
+```
 
 ## Performance
 
@@ -73,3 +236,4 @@ The initial algorithm and optimisations were taken from Joseph Birr-Pixton's
 * SHAs and HMAC-SHA: [RFC6234](https://tools.ietf.org/html/rfc6234)
 
 [MIM]: https://github.com/esl/MongooseIM
+[exml]: https://github.com/esl/exml/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The second element is always a binary, and the third is always the scram state.
 ```erlang
 -spec mech_step(fast_scram_state(), binary()) ->
     {ok,       final_message(), fast_scram_state()} |
-    {continue, next_message(),  fast_scram_state()} |
+    {continue,  next_message(), fast_scram_state()} |
     {error,    error_message(), fast_scram_state()}.
 ```
 
@@ -139,7 +139,7 @@ is available.
 Channel binding specification can also be given by `channel_binding => {Type, Data}`,
 where `Type` is the channel binding name, and `Data` is its associated payload.
 The default is `{undefined, <<>>}`, which will set the gs2 flag to no binding, that is, `<<"n">>`.
-If for example a client had channel binding, but saw the server no offering any,
+If for example a client had channel binding, but saw the server not offering any,
 this client should set the flag to `{none, <<>>}`: this will send the gs2 flag as `<<"y">>`.
 
 ### Server retrieval of the client's data

--- a/rebar.config
+++ b/rebar.config
@@ -1,12 +1,14 @@
 {erl_opts, [debug_info]}.
-{deps,
- []}.
+{deps, []}.
 
 {profiles, [
   {test, [
     {deps, [
       {statistics, {git, "https://github.com/NelsonVides/statistics.git", {branch, "master"}}},
       {proper, "1.3.0"}
+     ]},
+    {plugins, [
+       {rebar3_codecov, {git, "https://github.com/esl/rebar3_codecov.git", {ref, "6bd31cc"}}}
      ]},
     {erl_opts, [{d, 'STATISTICS'}]}
    ]}

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -1,17 +1,55 @@
 -module(fast_scram).
 -on_load(load/0).
 
+-include("types.hrl").
+
+-type configuration() :: map().
+
+-spec mech_new(configuration()) ->
+    {ok, fast_scram_state()} |
+    {continue, fast_scram_state()} |
+    {error, binary()}.
+
+-spec mech_append(fast_scram_state(), configuration()) ->
+    {ok, fast_scram_state()} |
+    {continue, fast_scram_state()} |
+    {error, binary()}.
+
 -export([hi/4]).
 
--type sha_type() :: crypto:sha1() | crypto:sha2().
+-export([mech_new/1]).
 
+-export([mech_append/2,
+         mech_get/2,
+         mech_get/3,
+         mech_set/3
+        ]).
+
+mech_new(Config) ->
+    fast_scram_configuration:mech_new(Config).
+
+mech_append(State, Config) ->
+    fast_scram_configuration:mech_append(State, Config).
+
+-spec mech_get(term(), fast_scram_state()) -> term().
+mech_get(Key, #fast_scram_state{data = PD}) ->
+    maps:get(Key, PD, undefined).
+
+-spec mech_get(term(), fast_scram_state(), term()) -> term().
+mech_get(Key, #fast_scram_state{data = PD}, Default) ->
+    maps:get(Key, PD, Default).
+
+-spec mech_set(term(), term(), fast_scram_state()) -> fast_scram_state().
+mech_set(Key, Value, #fast_scram_state{data = PD} = State) ->
+    State#fast_scram_state{data = PD#{Key => Value}}.
+
+%%%===================================================================
+%%% NIF
+%%%===================================================================
 -spec hi(sha_type(), binary(), binary(), non_neg_integer()) -> binary().
 hi(_Hash, _Password, _Salt, _IterationCount) ->
     erlang:nif_error(not_loaded).
 
-%%%===================================================================
-%%% Load NIF
-%%%===================================================================
 -spec load() -> any().
 load() ->
     code:ensure_loaded(crypto),

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -13,7 +13,7 @@
 
 -spec mech_step(fast_scram_state(), binary()) ->
     {ok,       final_message(), fast_scram_state()} |
-    {continue, next_message(),  fast_scram_state()} |
+    {continue,  next_message(), fast_scram_state()} |
     {error,    error_message(), fast_scram_state()}.
 
 -export([hi/4]).

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -3,23 +3,26 @@
 
 -include("types.hrl").
 
--type configuration() :: map().
+-type next_message() :: binary().
+-type error_message() :: binary().
+-type final_message() :: binary().
 
 -spec mech_new(configuration()) ->
     {ok, fast_scram_state()} |
-    {continue, fast_scram_state()} |
-    {error, binary()}.
+    {error, term()}.
 
--spec mech_append(fast_scram_state(), configuration()) ->
-    {ok, fast_scram_state()} |
-    {continue, fast_scram_state()} |
-    {error, binary()}.
+-spec mech_step(fast_scram_state(), binary()) ->
+    {ok,       final_message(), fast_scram_state()} |
+    {continue, next_message(),  fast_scram_state()} |
+    {error,    error_message(), fast_scram_state()}.
 
 -export([hi/4]).
 
--export([mech_new/1]).
+-export([mech_new/1,
+         mech_step/2
+        ]).
 
--export([mech_append/2,
+-export([
          mech_get/2,
          mech_get/3,
          mech_set/3
@@ -27,9 +30,6 @@
 
 mech_new(Config) ->
     fast_scram_configuration:mech_new(Config).
-
-mech_append(State, Config) ->
-    fast_scram_configuration:mech_append(State, Config).
 
 -spec mech_get(term(), fast_scram_state()) -> term().
 mech_get(Key, #fast_scram_state{data = PD}) ->
@@ -42,6 +42,267 @@ mech_get(Key, #fast_scram_state{data = PD}, Default) ->
 -spec mech_set(term(), term(), fast_scram_state()) -> fast_scram_state().
 mech_set(Key, Value, #fast_scram_state{data = PD} = State) ->
     State#fast_scram_state{data = PD#{Key => Value}}.
+
+%%% CLIENT STEPS
+mech_step(#fast_scram_state{
+             step = 1,
+             nonce = Nonce,
+             channel_binding = CbConfig,
+             data = PrivData
+            } = State, <<>>) ->
+    {GS2Header, ClientFirstBare} = fast_scram_attributes:client_first_message(
+                                     CbConfig, Nonce, PrivData),
+    ClientFirstMessage = <<GS2Header/binary, ClientFirstBare/binary>>,
+    NewState = fast_scram_parse_rules:append_to_auth_message_in_state(State, ClientFirstBare),
+    {continue, ClientFirstMessage, NewState#fast_scram_state{step = 3}};
+
+mech_step(#fast_scram_state{step = 3} = State, ServerIn) ->
+    case parse_server_first_message(ServerIn, State) of
+        {ok, #fast_scram_state{
+                nonce = Nonce,
+                challenge = Challenge,
+                channel_binding = CbConfig,
+                scram_definitions = Scram0,
+                data = PrivData
+               } = NewState} ->
+            ClientFinalNoProof = fast_scram_attributes:client_final_message_without_proof(
+                                   CbConfig, Nonce, PrivData),
+            Scram1 = fast_scram_parse_rules:append_to_auth_message(
+                       Scram0, <<",", ClientFinalNoProof/binary>>),
+            Scram2 = fast_scram_definitions:scram_definitions_pipe(Scram1, Challenge, PrivData),
+            ClientProof = Scram2#scram_definitions.client_proof,
+            ClientFinalMessage = fast_scram_attributes:client_final_message(
+                                   ClientFinalNoProof, ClientProof),
+            NewState1 = NewState#fast_scram_state{scram_definitions = Scram2},
+            {continue, ClientFinalMessage, NewState1#fast_scram_state{step = 5}};
+        {error, Reason} ->
+            {error, Reason, State}
+    end;
+
+mech_step(#fast_scram_state{step = 5} = State, ServerIn) ->
+    case parse_server_final_message(ServerIn, State) of
+        {ok, NewState} ->
+            {ok, <<>>, NewState};
+        {error, Reason} ->
+            {error, Reason, State}
+    end;
+
+%%% SERVER STEPS
+%%% An retrieve_mechanism function can add data to the state
+%%% For example when the username is needed in order to complete the state data
+mech_step(#fast_scram_state{step = 2} = State0, ClientIn) ->
+    case parse_client_first_message(ClientIn, State0) of
+        {ok, #fast_scram_state{data = PrivData} = State1} ->
+            FunRetrieve = maps:get(retrieve_mechanism, PrivData, fun(_) -> #{} end),
+            case apply_fun(FunRetrieve, State1) of
+                State2 = #fast_scram_state{} ->
+                    Nonce = State2#fast_scram_state.nonce,
+                    Challenge = State2#fast_scram_state.challenge,
+                    Scram0 = State2#fast_scram_state.scram_definitions,
+                    ServerFirstMsg = fast_scram_attributes:server_first_message(
+                                       Nonce, Challenge),
+                    Scram1 = fast_scram_definitions:scram_definitions_pipe(
+                               Scram0, Challenge, PrivData),
+                    Scram2 = fast_scram_parse_rules:append_to_auth_message(
+                               Scram1, <<",", ServerFirstMsg/binary>>),
+                    NewState1 = State2#fast_scram_state{scram_definitions = Scram2},
+                    {continue, ServerFirstMsg, NewState1#fast_scram_state{step = 4}};
+                {error, Reason} ->
+                    {error, Reason, State1}
+            end;
+        {error, Reason} ->
+            {error, Reason, State0}
+    end;
+
+mech_step(#fast_scram_state{step = 4} = State, ClientIn) ->
+    case parse_client_final_message(ClientIn, State) of
+        {ok, #fast_scram_state{
+                challenge = Challenge,
+                scram_definitions = Scram0,
+                data = PrivData
+               } = NewState} ->
+            GivenClientProof = maps:get(client_proof, PrivData),
+            Scram = fast_scram_definitions:scram_definitions_pipe(Scram0, Challenge, PrivData),
+            NewState1 = NewState#fast_scram_state{scram_definitions = Scram},
+            case check_proof(Scram, GivenClientProof) of
+                ok ->
+                    ServerSignature = Scram#scram_definitions.server_signature,
+                    ServerLastMessage = fast_scram_attributes:server_final_message(
+                                         base64:encode(ServerSignature)),
+                    {ok, ServerLastMessage, NewState1#fast_scram_state{step = 6}};
+                {error, Reason} ->
+                    ServerLastMessage = fast_scram_attributes:server_final_message({error, Reason}),
+                    {error, ServerLastMessage, NewState1}
+            end;
+        {error, Reason} ->
+            ServerLastMessage = fast_scram_attributes:server_final_message({error, Reason}),
+            {error, ServerLastMessage, State}
+    end.
+
+-type username_to_config() :: fun((username()) -> configuration()).
+-type username_to_state() :: fun((username(), fast_scram_state()) ->
+                                    {configuration(), fast_scram_state()}).
+
+-spec apply_fun(Fun, State) -> Result
+     when Fun :: username_to_config() | username_to_state(),
+          State :: fast_scram_state(),
+          Result :: fast_scram_state() | {error, term()}.
+apply_fun(Fun, State) when is_function(Fun, 1) ->
+    Username = fast_scram:mech_get(username, State),
+    Result = Fun(Username),
+    apply_result(Result, State);
+apply_fun(Fun, State) when is_function(Fun, 2) ->
+    Username = fast_scram:mech_get(username, State),
+    Result = Fun(Username, State),
+    apply_result(Result, State).
+
+apply_result({Config = #{}, State = #fast_scram_state{}}, _) ->
+    fast_scram_configuration:mech_append(State, Config);
+apply_result({State = #fast_scram_state{}, Config = #{}}, _) ->
+    fast_scram_configuration:mech_append(State, Config);
+apply_result(Config = #{}, State) ->
+    fast_scram_configuration:mech_append(State, Config);
+apply_result({error, Reason}, _) ->
+    {error, Reason}.
+
+-spec check_proof(scram_definitions(), binary()) -> ok | {error, binary()}.
+check_proof(#scram_definitions{client_proof = CalculatedClientProof}, GivenClientProof)
+  when CalculatedClientProof =:= GivenClientProof ->
+    ok;
+check_proof(#scram_definitions{hash_method = HashMethod,
+                               client_proof = <<>>,
+                               stored_key = StoredKey,
+                               client_signature = ClientSignature}, GivenClientProof) ->
+    ClientKey = fast_scram_definitions:client_proof(GivenClientProof, ClientSignature),
+    CalculatedStoredKey = fast_scram_definitions:stored_key(HashMethod, ClientKey),
+    case CalculatedStoredKey =:= StoredKey of
+        true -> ok;
+        _ -> {error, <<"invalid-proof">>}
+    end;
+check_proof(_, _) ->
+    {error, <<"invalid-proof">>}.
+
+%%%===================================================================
+%%% SCRAM parsing full messages
+%%%===================================================================
+%  client-first-message =
+%        gs2-cbind-flag "," [authzid] "," [reserved-mext ","] username "," nonce ["," extensions]
+-spec parse_client_first_message(binary(), fast_scram_state()) -> parse_return().
+parse_client_first_message(ClientIn, State0) ->
+    Rules = [
+             fun fast_scram_parse_rules:parse_gs2_cbind_flag/2,
+             fun fast_scram_parse_rules:parse_authzid/2,
+             fun fast_scram_parse_rules:parse_reserved_mext/2,
+             fun fast_scram_parse_rules:parse_username/2,
+             fun fast_scram_parse_rules:parse_nonce/2,
+             fun fast_scram_parse_rules:parse_extensions/2
+            ],
+    Chunks = binary:split(ClientIn, <<",">>, [global]),
+    case match_rules(Chunks, Rules, State0) of
+        {UnusedRules, State1 = #fast_scram_state{}}
+          when is_list(UnusedRules), length(UnusedRules) == 1 ->
+            ClientFirstMsgBare = extract_client_first_msg_bare_from_first(Chunks, ClientIn),
+            State2 = fast_scram_parse_rules:append_to_auth_message_in_state(
+                          State1, ClientFirstMsgBare),
+            {ok, State2};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+% server-first-message =
+%                   [reserved-mext ","] nonce "," salt ","
+%                   iteration-count ["," extensions]
+-spec parse_server_first_message(binary(), fast_scram_state()) -> parse_return().
+parse_server_first_message(ServerIn, State0) ->
+    Rules = [
+             fun fast_scram_parse_rules:parse_reserved_mext/2,
+             fun fast_scram_parse_rules:parse_nonce/2,
+             fun fast_scram_parse_rules:parse_salt/2,
+             fun fast_scram_parse_rules:parse_iteration_count/2,
+             fun fast_scram_parse_rules:parse_extensions/2
+            ],
+    ServerInChunks = binary:split(ServerIn, <<",">>, [global]),
+    case match_rules(ServerInChunks, Rules, State0) of
+        {UnusedRules, State1 = #fast_scram_state{}}
+          when is_list(UnusedRules), length(UnusedRules) == 1 ->
+            State2 = fast_scram_parse_rules:append_to_auth_message_in_state(
+                       State1, <<",", ServerIn/binary>>),
+            {ok, State2};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+% client-final-message =
+%                   channel-binding "," nonce ["," extensions] "," proof
+-spec parse_client_final_message(binary(), fast_scram_state()) -> parse_return().
+parse_client_final_message(ClientIn, State0) ->
+    Rules = [
+             fun fast_scram_parse_rules:parse_channel_binding/2,
+             fun fast_scram_parse_rules:parse_nonce/2,
+             fun fast_scram_parse_rules:parse_extensions/2,
+             fun fast_scram_parse_rules:parse_proof/2
+            ],
+    ClientInList = binary:split(ClientIn, <<",">>, [global]),
+    case match_rules(ClientInList, Rules, State0) of
+        {UnusedRules, State1 = #fast_scram_state{}}
+          when is_list(UnusedRules), length(UnusedRules) == 0 ->
+            ClientFinalNoProof = extract_client_final_no_proof(ClientIn),
+            State2 = fast_scram_parse_rules:append_to_auth_message_in_state(
+                       State1, <<",", ClientFinalNoProof/binary>>),
+            {ok, State2};
+        {error, Reason} ->
+            {error, Reason};
+        {_, #fast_scram_state{}} ->
+            {error, <<"other-error">>}
+    end.
+
+% server-final-message = (server-error / verifier)
+%                   ["," extensions]
+-spec parse_server_final_message(binary(), fast_scram_state()) -> parse_return().
+parse_server_final_message(ServerIn, State0) ->
+    Rules = [
+             fun fast_scram_parse_rules:parse_server_error_or_verifier/2,
+             fun fast_scram_parse_rules:parse_extensions/2
+            ],
+    ServerInChunks = binary:split(ServerIn, <<",">>, [global]),
+    case match_rules(ServerInChunks, Rules, State0) of
+        {UnusedRules, State1 = #fast_scram_state{}}
+          when is_list(UnusedRules), length(UnusedRules) == 1 ->
+            {ok, State1};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+extract_client_first_msg_bare_from_first([Gs2BindFlag, AuthZID | _], ClientIn) ->
+    NStart = byte_size(Gs2BindFlag) + byte_size(AuthZID) + 2,
+    binary:part(ClientIn, {NStart, byte_size(ClientIn) - NStart}).
+
+extract_client_final_no_proof(ClientIn) ->
+    {PStart, _} = binary:match(ClientIn, <<",p=">>),
+    binary:part(ClientIn, {0, PStart}).
+
+%%%===================================================================
+%%% Match parsing rules
+%%%===================================================================
+match_rules(Inputs, Rules, State) ->
+    lists:foldl(
+      fun(_, {error, Reason}) ->
+              {error, Reason};
+         (Input, {RulesLeft, St}) ->
+              apply_rules_until_match(Input, RulesLeft, St)
+      end, {Rules, State}, Inputs).
+
+apply_rules_until_match(_, [], _) ->
+    {error, <<"error-too-much-input">>};
+apply_rules_until_match(Input, [Rule | RulesLeft], State) ->
+    case Rule(Input, State) of
+        {ok, NewState} ->
+            {RulesLeft, NewState};
+        {skip_rule, State} ->
+            apply_rules_until_match(Input, RulesLeft, State);
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
 %%%===================================================================
 %%% NIF

--- a/src/fast_scram_attributes.erl
+++ b/src/fast_scram_attributes.erl
@@ -1,0 +1,189 @@
+-module(fast_scram_attributes).
+
+-include("types.hrl").
+
+-export([
+         reserved_scram_codes/0,
+         gs2_header/2,
+         nonce/1,
+         cbind_input/2,
+         client_first_message_bare/2,
+         client_final_message_without_proof/3,
+         server_first_message/2,
+         client_first_message/3,
+         client_final_message/2,
+         server_final_message/1
+        ]).
+
+%%%===================================================================
+%%% SCRAM attributes
+%%%===================================================================
+
+% -type scram_attribute() ::
+%     'a=' | % auth as a different user
+%     'n=' | % username, auth identity
+%     'm=' | % reserved for extensibility
+%     'r=' | % nonce
+%     'c=' | % GS2 header and channel binding data
+%     's=' | % base64 salt
+%     'i=' | % iteration count
+%     'p=' | % base64 ClientProof
+%     'v=' | % base64 ServerSignature
+%     'e='.  % error that occurred during auth
+reserved_scram_codes() ->
+    [<<"p">>, <<"n">>, <<"r">>,
+     <<"c">>, <<"s">>, <<"i">>,
+     <<"a">>, <<"v">>, <<"e">>].
+
+
+% gs2-cbind-flag  = ("p=" cb-name) / "n" / "y"
+%                   ;; "n" -> client doesn't support channel binding.
+%                   ;; "y" -> client does support channel binding
+%                   ;;        but thinks the server does not.
+%                   ;; "p" -> client requires channel binding.
+%                   ;; The selected channel binding follows "p=".
+gs2_cbind_flag(undefined) ->
+    <<"n">>;
+gs2_cbind_flag(none) ->
+    <<"y">>;
+gs2_cbind_flag(CB) when is_binary(CB) ->
+    <<"p=", CB/binary>>.
+
+% authzid         = "a=" saslname
+%                   ;; Protocol specific.
+authzid(ID) when is_binary(ID) ->
+    ID.
+
+% gs2-header      = gs2-cbind-flag "," [ authzid ] ","
+%                   ;; GS2 header for SCRAM
+%                   ;; (the actual GS2 header includes an optional
+%                   ;; flag to indicate that the GSS mechanism is not
+%                   ;; "standard", but since SCRAM is "standard", we
+%                   ;; don't include that flag).
+gs2_header(#channel_binding{variant = Variant}, Data) ->
+    AuthZID = maps:get(auth_zid, Data, <<>>),
+    <<(gs2_cbind_flag(Variant))/binary, ",",
+      (authzid(AuthZID))/binary, ",">>.
+
+% reserved-mext  = "m=" 1*(value-char)
+%                   ;; Reserved for signaling mandatory extensions.
+%                   ;; The exact syntax will be defined in
+%                   ;; the future.
+reserved_mext() ->
+    <<"">>.
+
+% username        = "n=" saslname
+%                   ;; Usernames are prepared using SASLprep.
+username(Username) ->
+    <<"n=", Username/binary>>.
+
+% nonce           = "r=" c-nonce [s-nonce]
+%                   ;; Second part provided by server.
+nonce(#nonce{client = CNonce, server = SNonce}) ->
+    <<"r=", CNonce/binary, SNonce/binary>>.
+
+% extensions = attr-val *("," attr-val)
+%                   ;; All extensions are optional,
+%                   ;; i.e., unrecognized attributes
+%                   ;; not defined in this document
+%                   ;; MUST be ignored.
+extensions() ->
+    <<>>.
+
+%salt            = "s=" base64
+salt(Salt) ->
+    <<"s=", (base64:encode(Salt))/binary>>.
+
+% iteration-count = "i=" posit-number
+%                   ;; A positive number.
+iteration_count(IterationCount) when ?is_positive_integer(IterationCount) ->
+    <<"i=", (integer_to_binary(IterationCount))/binary>>.
+
+% channel-binding = "c=" base64
+%                      ;; base64 encoding of cbind-input.
+channel_binding(#channel_binding{data = CBindData} = CBindConfig, Data) ->
+    <<"c=", (cbind_input(gs2_header(CBindConfig, Data), CBindData))/binary>>.
+
+cbind_input(GS2Header, CBindData) ->
+    base64:encode(<<GS2Header/binary, CBindData/binary>>).
+
+% proof           = "p=" base64
+proof(Proof)->
+    <<"p=", (base64:encode(Proof))/binary>>.
+
+%%%===================================================================
+%%% SCRAM Messages
+%%%===================================================================
+% client-first-message-bare =
+%                   [reserved-mext ","]
+%                   username "," nonce ["," extensions]
+client_first_message_bare(#{username := Username}, Nonce)->
+    <<(reserved_mext())/binary,
+      (username(Username))/binary, ",",
+      (nonce(Nonce))/binary,
+      (extensions())/binary>>.
+
+% client-final-message-without-proof =
+%                   channel-binding "," nonce ["," extensions]
+client_final_message_without_proof(CBConfig, Nonce, Data) ->
+    <<(channel_binding(CBConfig, Data))/binary, ",",
+      (nonce(Nonce))/binary,
+      (extensions())/binary>>.
+
+% client-first-message =
+%                   gs2-header client-first-message-bare
+client_first_message(CbConfig, Nonce, Data) ->
+    GS2Header = gs2_header(CbConfig, Data),
+    ClientFirstMessageBare = client_first_message_bare(Data, Nonce),
+    {GS2Header, ClientFirstMessageBare}.
+
+% server-first-message =
+%                   [reserved-mext ","] nonce "," salt ","
+%                   iteration-count ["," extensions]
+server_first_message(Nonce, #challenge{salt = Salt, it_count = IterationCount}) ->
+    <<(reserved_mext())/binary,
+      (nonce(Nonce))/binary, ",",
+      (salt(Salt))/binary, ",",
+      (iteration_count(IterationCount))/binary,
+      (extensions())/binary>>.
+
+% client-final-message =
+%                   client-final-message-without-proof "," proof
+client_final_message(ClientFinalNoProof, ClientProof) ->
+    <<ClientFinalNoProof/binary, ",",
+      (proof(ClientProof))/binary>>.
+
+% server-error = "e=" server-error-value
+
+% server-error-value = "invalid-encoding" /
+%                "extensions-not-supported" /  ; unrecognized 'm' value
+%                "invalid-proof" /
+%                "channel-bindings-dont-match" /
+%                "server-does-support-channel-binding" /
+%                  ; server does not support channel binding
+%                "channel-binding-not-supported" /
+%                "unsupported-channel-binding-type" /
+%                "unknown-user" /
+%                "invalid-username-encoding" /
+%                  ; invalid username encoding (invalid UTF-8 or
+%                  ; SASLprep failed)
+%                "no-resources" /
+%                "other-error" /
+%                server-error-value-ext
+%         ; Unrecognized errors should be treated as "other-error".
+%         ; In order to prevent information disclosure, the server
+%         ; may substitute the real reason with "other-error".
+
+% server-error-value-ext = value
+%         ; Additional error reasons added by extensions
+%         ; to this document.
+
+% verifier        = "v=" base64
+%                   ;; base-64 encoded ServerSignature.
+
+% server-final-message = (server-error / verifier)
+%                   ["," extensions]
+server_final_message({error, Reason}) ->
+    <<"e=", Reason/binary, (extensions())/binary>>;
+server_final_message(Verifier) when is_binary(Verifier) ->
+    <<"v=", Verifier/binary, (extensions())/binary>>.

--- a/src/fast_scram_configuration.erl
+++ b/src/fast_scram_configuration.erl
@@ -1,0 +1,78 @@
+-module(fast_scram_configuration).
+
+-include("types.hrl").
+-define(DEFAULT_NONCE_SIZE, 16).
+-define(f, #fast_scram_state).
+
+%% @doc This only adds a key into the state, verifying typeness, but not if it is repeated.
+-type option() :: atom().
+-type value() :: term().
+-spec set_val_in_state(option(), value(), fast_scram_state()) ->
+    fast_scram_state() | {error, atom(), term()}.
+set_val_in_state(entity, Ent, ?f{} = St) when is_atom(Ent) ->
+    case Ent of
+        client -> St?f{step = 1};
+        server -> St?f{step = 2}
+    end;
+
+set_val_in_state(nonce_size, Num, ?f{} = St) when ?is_positive_integer(Num) ->
+    Bin = base64:encode(crypto:strong_rand_bytes(Num)),
+    case St?f.step of
+        1 -> St?f{nonce = #nonce{client = Bin}};
+        2 -> St?f{nonce = #nonce{server = Bin}}
+    end;
+set_val_in_state(nonce, Bin, ?f{} = St) when is_binary(Bin) ->
+    case St?f.step of
+        1 -> St?f{nonce = #nonce{client = Bin}};
+        2 -> St?f{nonce = #nonce{server = Bin}}
+    end;
+
+set_val_in_state(it_count, Num, ?f{challenge = Ch} = St) when ?is_positive_integer(Num) ->
+    St?f{challenge = Ch#challenge{it_count = Num}};
+set_val_in_state(salt, Bin, ?f{challenge = Ch} = St) when is_binary(Bin) ->
+    St?f{challenge = Ch#challenge{salt = Bin}};
+
+set_val_in_state(channel_binding, {Type, Data}, ?f{channel_binding = CB} = St)
+  when is_atom(Type) orelse is_binary(Type), is_binary(Data) ->
+    St?f{channel_binding = CB#channel_binding{variant = Type, data = Data}};
+
+set_val_in_state(hash_method, HM, ?f{scram_definitions = SD} = St) when ?is_valid_hash(HM) ->
+    St?f{scram_definitions = SD#scram_definitions{hash_method = HM}};
+set_val_in_state(salted_password, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{salted_password = Bin}};
+set_val_in_state(client_key, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{client_key = Bin}};
+set_val_in_state(stored_key, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{stored_key = Bin}};
+set_val_in_state(client_signature, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{client_signature = Bin}};
+set_val_in_state(client_proof, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{client_proof = Bin}};
+set_val_in_state(server_key, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{server_key = Bin}};
+set_val_in_state(server_signature, Bin, ?f{scram_definitions = SD} = St) when is_binary(Bin) ->
+    St?f{scram_definitions = SD#scram_definitions{server_signature = Bin}};
+
+%% Stuff to data
+set_val_in_state(username, UN, ?f{data = PD} = St) when is_binary(UN) ->
+    St?f{data = PD#{username => UN}};
+set_val_in_state(password, PW, ?f{data = PD} = St) when is_binary(PW) ->
+    St?f{data = PD#{password => PW}};
+
+set_val_in_state(cached_challenge, {It, Salt}, ?f{data = PD} = St)
+  when ?is_positive_integer(It), is_binary(Salt) ->
+    Challenge = #challenge{it_count = It, salt = Salt},
+    St?f{data = PD#{challenge => Challenge}};
+set_val_in_state(cached_challenge, {Salt, It}, ?f{data = PD} = St)
+  when ?is_positive_integer(It), is_binary(Salt) ->
+    Challenge = #challenge{it_count = It, salt = Salt},
+    St?f{data = PD#{challenge => Challenge}};
+
+set_val_in_state(retrieve_mechanism, Fun, ?f{data = PD} = St)
+  when is_function(Fun, 1); is_function(Fun, 2) ->
+    St?f{data = PD#{retrieve_mechanism => Fun}};
+
+set_val_in_state(WrongKey, _, ?f{}) ->
+    {error, wrong_key, WrongKey};
+set_val_in_state(_, _, {error, wrong_key, _} = Error) ->
+    Error.

--- a/src/fast_scram_definitions.erl
+++ b/src/fast_scram_definitions.erl
@@ -12,6 +12,10 @@
          server_signature/3
         ]).
 
+-export([
+         scram_definitions_pipe/3
+        ]).
+
 %%%===================================================================
 %%% SCRAM Definitions
 %%%===================================================================
@@ -68,3 +72,94 @@ crypto_hmac(Sha, Bin1, Bin2) ->
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:hmac(Sha, Bin1, Bin2).
 -endif.
+
+-spec scram_definitions_pipe(scram_definitions(), challenge(), map()) ->
+    scram_definitions().
+%% Typical scenario, auth_message is full and we only have the plain password
+scram_definitions_pipe(
+  #scram_definitions{hash_method = HashMethod,
+                     salted_password = <<>>,
+                     auth_message = AuthMessage} = Scram,
+  #challenge{salt = Salt, it_count = ItCount},
+  #{password := Password}) when AuthMessage =/= <<>> ->
+    SaltedPassword = salted_password(HashMethod, Password, Salt, ItCount),
+    ClientKey = client_key(HashMethod, SaltedPassword),
+    StoredKey = stored_key(HashMethod, ClientKey),
+    ClientSignature = client_signature(HashMethod, StoredKey, AuthMessage),
+    ClientProof = client_proof(ClientKey, ClientSignature),
+    ServerKey = server_key(HashMethod, SaltedPassword),
+    ServerSignature = server_signature(HashMethod, ServerKey, AuthMessage),
+    Scram#scram_definitions{
+       salted_password = SaltedPassword,
+       client_key = ClientKey,
+       stored_key = StoredKey,
+       auth_message = AuthMessage,
+       client_signature = ClientSignature,
+       client_proof = ClientProof,
+       server_key = ServerKey,
+       server_signature = ServerSignature
+      };
+%% We have a cached challenge, we need to verify if it is correct
+scram_definitions_pipe(
+  #scram_definitions{hash_method = HashMethod, auth_message = AuthMessage} = Scram,
+  #challenge{} = GivenChallenge,
+  #{challenge := StoredChallenge} = Data) ->
+    case GivenChallenge =:= StoredChallenge of
+        true -> % This means that the client has cached the challenge correctly
+            partial_compute(Scram);
+        false -> % Invalid cache, remove all knowledge and try again
+            ScramWithoutCached = #scram_definitions{hash_method = HashMethod, auth_message = AuthMessage},
+            DataWithoutCached = maps:remove(challenge, Data),
+            scram_definitions_pipe(ScramWithoutCached, GivenChallenge, DataWithoutCached)
+    end;
+scram_definitions_pipe(Scram, _, _) ->
+    partial_compute(Scram).
+
+partial_compute(Scram =
+  #scram_definitions{
+     hash_method = HashMethod, auth_message = AuthMessage,
+     client_key = ClientKey, server_key = ServerKey
+    }) when ClientKey =/= <<>>, ServerKey =/= <<>> ->
+    StoredKey = stored_key(HashMethod, ClientKey),
+    ClientSignature = client_signature(HashMethod, StoredKey, AuthMessage),
+    ClientProof = client_proof(ClientKey, ClientSignature),
+    ServerSignature = server_signature(HashMethod, ServerKey, AuthMessage),
+    Scram#scram_definitions{
+      stored_key = StoredKey,
+      client_signature = ClientSignature,
+      client_proof = ClientProof,
+      server_signature = ServerSignature
+     };
+partial_compute(Scram =
+  #scram_definitions{
+     hash_method = HashMethod, auth_message = AuthMessage,
+     stored_key = StoredKey, server_key = ServerKey
+    }) when StoredKey =/= <<>>, ServerKey =/= <<>> ->
+    ClientSignature = client_signature(HashMethod, StoredKey, AuthMessage),
+    ServerSignature = server_signature(HashMethod, ServerKey, AuthMessage),
+    Scram#scram_definitions{
+      client_signature = ClientSignature,
+      server_signature = ServerSignature
+     };
+partial_compute(Scram =
+  #scram_definitions{
+     hash_method = HashMethod, auth_message = AuthMessage,
+     salted_password = SaltedPassword
+    }) when SaltedPassword =/= <<>> ->
+    ClientKey = client_key(HashMethod, SaltedPassword),
+    StoredKey = stored_key(HashMethod, ClientKey),
+    ClientSignature = client_signature(HashMethod, StoredKey, AuthMessage),
+    ClientProof = client_proof(ClientKey, ClientSignature),
+    ServerKey = server_key(HashMethod, SaltedPassword),
+    ServerSignature = server_signature(HashMethod, ServerKey, AuthMessage),
+    Scram#scram_definitions{
+       client_key = ClientKey,
+       stored_key = StoredKey,
+       client_signature = ClientSignature,
+       client_proof = ClientProof,
+       server_key = ServerKey,
+       server_signature = ServerSignature
+      };
+partial_compute(Scram) ->
+    ?LOG_DEBUG(#{what => scram_no_pipe_match}),
+    Scram.

--- a/src/fast_scram_definitions.erl
+++ b/src/fast_scram_definitions.erl
@@ -1,0 +1,70 @@
+-module(fast_scram_definitions).
+
+-include("types.hrl").
+
+-export([
+         salted_password/4,
+         client_key/2,
+         stored_key/2,
+         client_signature/3,
+         client_proof/2,
+         server_key/2,
+         server_signature/3
+        ]).
+
+%%%===================================================================
+%%% SCRAM Definitions
+%%%===================================================================
+%% SaltedPassword  := Hi(Normalize(password), salt, i)
+%% ClientKey       := HMAC(SaltedPassword, "Client Key")
+%% StoredKey       := H(ClientKey)
+%% AuthMessage     := client-first-message-bare + "," +
+%%                    server-first-message + "," +
+%%                    client-final-message-without-proof
+%% ClientSignature := HMAC(StoredKey, AuthMessage)
+%% ClientProof     := ClientKey XOR ClientSignature
+%% ServerKey       := HMAC(SaltedPassword, "Server Key")
+%% ServerSignature := HMAC(ServerKey, AuthMessage)
+
+-spec salted_password(sha_type(), binary(), binary(), non_neg_integer()) -> binary().
+salted_password(Sha, Password, Salt, IterationCount)
+  when ?is_valid_hash(Sha), is_binary(Password), is_binary(Salt), ?is_positive_integer(IterationCount) ->
+    fast_scram:hi(Sha, Password, Salt, IterationCount).
+
+-spec client_key(sha_type(), binary()) -> binary().
+client_key(Sha, SaltedPassword)
+  when ?is_valid_hash(Sha), is_binary(SaltedPassword) ->
+    crypto_hmac(Sha, SaltedPassword, <<"Client Key">>).
+
+-spec stored_key(sha_type(), binary()) -> binary().
+stored_key(Sha, ClientKey)
+  when ?is_valid_hash(Sha), is_binary(ClientKey) ->
+    crypto:hash(Sha, ClientKey).
+
+-spec client_signature(sha_type(), binary(), binary()) -> binary().
+client_signature(Sha, StoredKey, AuthMessage)
+  when ?is_valid_hash(Sha), is_binary(StoredKey), is_binary(AuthMessage) ->
+    crypto_hmac(Sha, StoredKey, AuthMessage).
+
+-spec client_proof(binary(), binary()) -> binary().
+client_proof(ClientKey, ClientSignature)
+  when is_binary(ClientKey), is_binary(ClientSignature) ->
+    crypto:exor(ClientKey, ClientSignature).
+
+-spec server_key(sha_type(), binary()) -> binary().
+server_key(Sha, SaltedPassword)
+  when ?is_valid_hash(Sha), is_binary(SaltedPassword) ->
+    crypto_hmac(Sha, SaltedPassword, <<"Server Key">>).
+
+-spec server_signature(sha_type(), binary(), binary()) -> binary().
+server_signature(Sha, ServerKey, AuthMessage)
+  when ?is_valid_hash(Sha), is_binary(ServerKey), is_binary(AuthMessage) ->
+    crypto_hmac(Sha, ServerKey, AuthMessage).
+
+-if(?OTP_RELEASE >= 22).
+crypto_hmac(Sha, Bin1, Bin2) ->
+    crypto:mac(hmac, Sha, Bin1, Bin2).
+-else.
+crypto_hmac(Sha, Bin1, Bin2) ->
+    crypto:hmac(Sha, Bin1, Bin2).
+-endif.

--- a/src/fast_scram_parse_rules.erl
+++ b/src/fast_scram_parse_rules.erl
@@ -1,0 +1,230 @@
+-module(fast_scram_parse_rules).
+
+-include("types.hrl").
+
+-export([
+        parse_gs2_cbind_flag/2,
+        parse_authzid/2,
+        parse_username/2,
+        parse_nonce/2,
+        parse_salt/2,
+        parse_iteration_count/2,
+        parse_reserved_mext/2,
+        parse_extensions/2,
+        parse_proof/2,
+        parse_channel_binding/2,
+        parse_server_error_or_verifier/2
+        ]).
+
+-spec parse_gs2_cbind_flag(binary(), fast_scram_state()) -> parse_return().
+parse_gs2_cbind_flag(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_gs2_cbind_flag(CBind, #fast_scram_state{channel_binding = CbConfig} = State) ->
+    % NOTE: if the client doesn't support channel-binding, remove it from the state
+    case supported_channel_binding_flag(CBind, CbConfig) of
+        #channel_binding{} = NewCbConfig ->
+            {ok, State#fast_scram_state{channel_binding = NewCbConfig}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec parse_authzid(binary(), fast_scram_state()) -> parse_return().
+parse_authzid(<<>>, State) ->
+    {ok, State};
+parse_authzid(<<"a=", _Rest/binary>>, _State) ->
+    {error, <<"authzid-flag-not-supported">>};
+parse_authzid(_, _State) ->
+    {error, <<"no-resources">>}.
+
+% Mandatory extensions sent by one peer but not understood by the
+% other MUST cause authentication failure (the server SHOULD send
+% the "extensions-not-supported" server-error-value).
+% Unknown optional extensions MUST be ignored upon receipt.
+-spec parse_reserved_mext(binary(), fast_scram_state()) -> parse_return().
+parse_reserved_mext(<<"m=", _/binary>>, _State) ->
+    {error, <<"extensions-not-supported">>};
+parse_reserved_mext(_, State) ->
+    {skip_rule, State}.
+
+-spec parse_username(binary(), fast_scram_state()) -> parse_return().
+parse_username(<<>>, _State) ->
+    {error, <<"unknown-user">>};
+parse_username(<<"n=", UnescapedUsername/binary>>, #fast_scram_state{data = Data} = State) ->
+    case replace_2c_3d(UnescapedUsername) of
+        {ok, EscapedUsername} ->
+            case maps:get(username, Data, undefined) of
+                CachedName when is_binary(CachedName), CachedName =/= EscapedUsername ->
+                    {error, <<"unknown-user">>};
+                _ ->
+                    NewData = Data#{username => EscapedUsername},
+                    {ok, State#fast_scram_state{data = NewData}}
+            end;
+        E -> E
+    end;
+parse_username(_, _) ->
+    {error, <<"other-error">>}.
+
+-spec parse_nonce(binary(), fast_scram_state()) -> parse_return().
+parse_nonce(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_nonce(<<"r=", Nonce/binary>>, State) ->
+    case update_append_nonce(Nonce, State#fast_scram_state.nonce) of
+        #nonce{} = N ->
+            {ok, State#fast_scram_state{nonce = N}};
+        {error, _} = E ->
+            E
+    end;
+parse_nonce(_, _) ->
+    {error, <<"other-error">>}.
+
+-spec parse_salt(binary(), fast_scram_state()) -> parse_return().
+parse_salt(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_salt(<<"s=", Salt/binary>>, State) ->
+    Challenge = State#fast_scram_state.challenge,
+    {ok, State#fast_scram_state{challenge = Challenge#challenge{salt = base64:decode(Salt)}}};
+parse_salt(_, _) ->
+    {error, <<"other-error">>}.
+
+-spec parse_iteration_count(binary(), fast_scram_state()) -> parse_return().
+parse_iteration_count(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_iteration_count(<<"i=", ItCount/binary>>, State) ->
+    Challenge = State#fast_scram_state.challenge,
+    case catch binary_to_integer(ItCount) of
+        It when ?is_positive_integer(It) ->
+            {ok, State#fast_scram_state{challenge = Challenge#challenge{it_count = It}}};
+        _ ->
+            {error, <<"invalid-iteration-count">>}
+    end;
+parse_iteration_count(_, _) ->
+    {error, <<"other-error">>}.
+
+-spec parse_extensions(binary(), fast_scram_state()) -> parse_return().
+parse_extensions(<<>>, _) ->
+    {error, <<"other-error">>};
+parse_extensions(<<"m=", _/binary>>, _) ->
+    {error, <<"extensions-not-supported">>};
+parse_extensions(<<Char:1/binary, _/binary>>, State) ->
+    case lists:any(fun(El) -> Char =:= El end,
+                   fast_scram_attributes:reserved_scram_codes()) of
+        true -> {skip_rule, State};
+        false -> {error, <<"extensions-not-supported">>}
+    end.
+
+-spec parse_proof(binary(), fast_scram_state()) -> parse_return().
+parse_proof(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_proof(<<"p=">>, _State) ->
+    {error, <<"invalid-proof">>};
+parse_proof(<<"p=", Proof0/binary>>,
+            #fast_scram_state{data = Data} = State) ->
+    Proof = base64:decode(Proof0),
+    {ok, State#fast_scram_state{data = Data#{client_proof => Proof}}}.
+
+-spec parse_channel_binding(binary(), fast_scram_state()) -> parse_return().
+parse_channel_binding(<<>>, _State) ->
+    {error, <<"no-resources">>};
+parse_channel_binding(<<"c=", CB/binary>>, #fast_scram_state{channel_binding = CbConfig,
+                                                        data = Data} = State) ->
+    case verify_cbind_input(CB, CbConfig, Data) of
+        ok ->
+            {ok, State};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+parse_channel_binding(_, _) ->
+    {error, <<"no-resources">>}.
+
+-spec parse_server_error_or_verifier(binary(), fast_scram_state()) -> parse_return().
+parse_server_error_or_verifier(
+  <<"v=", Verifier/binary>>,
+  #fast_scram_state{scram_definitions = #scram_definitions{} = ScramDefs} = State) ->
+    ServerSignature = ScramDefs#scram_definitions.server_signature,
+    case base64:decode(Verifier) of
+        ServerSignature ->
+            {ok, State};
+        _ ->
+            {error, <<"authentication-failure">>}
+    end;
+parse_server_error_or_verifier(<<"e=", Error/binary>>, _State) ->
+    {error, Error}.
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Replace "=2C" with "," and "=3D" with "=". Return invalid-username-encoding
+%% if any "=" char is not preceded with either  "2C" or "3D".
+%% @end
+%%--------------------------------------------------------------------
+-spec replace_2c_3d(binary()) -> {ok, binary()} | {error, binary()}.
+replace_2c_3d(UnescapedUsername) ->
+    case binary:match(UnescapedUsername, <<"=">>) of
+        nomatch ->
+            {ok, UnescapedUsername};
+        _ ->
+            ReplacedEqual = binary:replace(UnescapedUsername, <<"=3D">>, <<"=">>, [global]),
+            EscapedUsername = binary:replace(ReplacedEqual, <<"=2C">>, <<",">>, [global]),
+            case binary:match(EscapedUsername, <<"=">>) of
+                nomatch ->
+                    {ok, EscapedUsername};
+                _ ->
+                    {error, <<"invalid-username-encoding">>}
+            end
+    end.
+
+-spec supported_channel_binding_flag(binary(), channel_binding()) ->
+    channel_binding() | {error, binary()}.
+supported_channel_binding_flag(
+  <<"p=", Type/binary>>,
+  #channel_binding{variant = Type} = CbConfig) when Type =/= undefined ->
+    CbConfig;
+supported_channel_binding_flag(
+  <<"p=", _Type/binary>>,
+  #channel_binding{variant = OtherType}) when OtherType =/= undefined ->
+    {error, <<"unsupported-channel-binding-type">>};
+supported_channel_binding_flag(
+  <<"p=", _Type/binary>>,
+  #channel_binding{variant = undefined}) ->
+    {error, <<"channel-binding-not-supported">>};
+supported_channel_binding_flag(
+  <<"y">>,
+  #channel_binding{variant = undefined} = CbConfig) ->
+    CbConfig;
+supported_channel_binding_flag(
+  <<"y">>,
+  #channel_binding{variant = Type}) when Type =/= undefined ->
+    {error, <<"server-does-support-channel-binding">>};
+supported_channel_binding_flag(
+  <<"n">>,
+  CbConfig) ->
+    CbConfig#channel_binding{variant = undefined};
+supported_channel_binding_flag(_, _) ->
+    {error, <<"other-error">>}.
+
+-spec update_append_nonce(binary(), nonce()) -> nonce() | {error, binary()}.
+update_append_nonce(ClientNonce, #nonce{client = <<>>} = Nonce) ->
+    Nonce#nonce{client = ClientNonce};
+update_append_nonce(FullNonce, #nonce{client = Client, server = <<>>} = Nonce) ->
+    case binary:longest_common_prefix([FullNonce, Client]) of
+        N when N == byte_size(Client) ->
+            Nonce#nonce{server = binary:part(FullNonce, {N, byte_size(FullNonce) - N})};
+        _ ->
+            {error, <<"invalid-nonce">>}
+    end;
+update_append_nonce(FullNonce, #nonce{client = Client, server = Server} = Nonce) ->
+    case FullNonce == <<Client/binary, Server/binary>> of
+        true ->
+            Nonce;
+        _ ->
+            {error, <<"invalid-nonce">>}
+    end.
+
+-spec verify_cbind_input(binary(), channel_binding(), map()) -> ok | {error, binary()}.
+verify_cbind_input(CBindInput, #channel_binding{data = CBindData} = CBConfig, Data) ->
+    Constructed = fast_scram_attributes:cbind_input(
+     fast_scram_attributes:gs2_header(CBConfig, Data),
+     CBindData),
+    case Constructed =:= CBindInput of
+        true -> ok;
+        false -> {error, <<"channel-bindings-dont-match">>}
+    end.

--- a/src/fast_scram_parse_rules.erl
+++ b/src/fast_scram_parse_rules.erl
@@ -15,6 +15,10 @@
         parse_channel_binding/2,
         parse_server_error_or_verifier/2
         ]).
+-export([
+        append_to_auth_message/2,
+        append_to_auth_message_in_state/2
+        ]).
 
 -spec parse_gs2_cbind_flag(binary(), fast_scram_state()) -> parse_return().
 parse_gs2_cbind_flag(<<>>, _State) ->
@@ -149,6 +153,18 @@ parse_server_error_or_verifier(
     end;
 parse_server_error_or_verifier(<<"e=", Error/binary>>, _State) ->
     {error, Error}.
+
+-spec append_to_auth_message(scram_definitions(), binary()) -> scram_definitions().
+append_to_auth_message(ScramDefs, NewChunk) ->
+    CurrentAuthMessage = ScramDefs#scram_definitions.auth_message,
+    NewAppendedAuthMessage = <<CurrentAuthMessage/binary, NewChunk/binary>>,
+    ScramDefs#scram_definitions{auth_message = NewAppendedAuthMessage}.
+
+-spec append_to_auth_message_in_state(fast_scram_state(), binary()) -> fast_scram_state().
+append_to_auth_message_in_state(State, NewChunk) ->
+    ScramDefs0 = State#fast_scram_state.scram_definitions,
+    ScramDefs1 = append_to_auth_message(ScramDefs0, NewChunk),
+    State#fast_scram_state{scram_definitions = ScramDefs1}.
 
 %%--------------------------------------------------------------------
 %% @doc

--- a/src/types.hrl
+++ b/src/types.hrl
@@ -1,0 +1,62 @@
+-include_lib("kernel/include/logger.hrl").
+
+-define(is_positive_integer(N), is_integer(N) andalso N > 0).
+-define(is_valid_hash(H), H == sha orelse
+        H == sha224 orelse H == sha256 orelse
+        H == sha384 orelse H == sha512).
+
+-type sha_type() :: crypto:sha1() | crypto:sha2().
+
+-type username() :: binary().
+-type auth_keys() :: password | salted_password | client_key | stored_key | server_key.
+-type auth_data() :: #{auth_keys() => binary()}.
+-type configuration() :: map().
+-type retrieve_mechanism() :: fun((username()) -> configuration())
+                            | fun((username(), fast_scram_state()) ->
+                                    {configuration(), fast_scram_state()}).
+
+-type parse_return() :: {ok, fast_scram_state()} | {error, binary()}.
+
+-record(nonce, {
+          client = <<>> :: binary(),
+          server = <<>> :: binary()}
+       ).
+-type nonce() :: #nonce{}.
+
+-record(challenge, {
+          salt = <<>>            :: binary(),
+          it_count = 1           :: pos_integer()
+         }).
+-type challenge() :: #challenge{}.
+
+-record(channel_binding, {
+          variant = undefined :: plus_variant(),
+          data = <<>> :: binary()
+         }).
+-type channel_binding() :: #channel_binding{}.
+-type plus_variant() :: undefined | none | binary().
+
+-record(scram_definitions, {
+          hash_method      :: sha_type(),
+          salted_password  = <<>> :: binary(), %Hi(Normalize(password), salt, i),
+          client_key       = <<>> :: binary(), %HMAC(SaltedPassword, "Client Key"),
+          stored_key       = <<>> :: binary(), %H(ClientKey),
+          auth_message     = <<>> :: binary(), %client-first-message-bare + "," +
+                                               %server-first-message + "," +
+                                               %client-final-message-without-proof
+          client_signature = <<>> :: binary(), %HMAC(StoredKey, AuthMessage),
+          client_proof     = <<>> :: binary(), %ClientKey XOR ClientSignature,
+          server_key       = <<>> :: binary(), %HMAC(SaltedPassword, "Server Key"),
+          server_signature = <<>> :: binary()  %HMAC(ServerKey, AuthMessage)
+         }).
+-type scram_definitions() :: #scram_definitions{}.
+
+-record(fast_scram_state, {
+          step :: 1..6, %% Steps 1 & 3 are client, 2 & 4 are server
+          nonce = #nonce{} :: nonce(),
+          challenge = #challenge{} :: challenge(),
+          channel_binding = #channel_binding{} :: channel_binding(),
+          scram_definitions = #scram_definitions{} :: scram_definitions(),
+          data = #{} :: map()
+         }).
+-type fast_scram_state() :: #fast_scram_state{}.

--- a/test/scram_SUITE.erl
+++ b/test/scram_SUITE.erl
@@ -1,0 +1,663 @@
+-module(scram_SUITE).
+
+-include("src/types.hrl").
+
+%% API
+-export([all/0, groups/0]).
+
+%% test cases
+-export([
+         regular_scram_authentication_example_from_the_rfc/1,
+         regular_scram_authentication/1,
+         wrong_configuration_key/1,
+         configuration_client_sends_wrong_username/1,
+         configuration_cached_keys_works_easily/0,
+         configuration_cached_keys_works_easily/1,
+         configuration_cached_keys_works_easily_v2/0,
+         configuration_cached_keys_works_easily_v2/1,
+         configuration_cached_wrong_simply_recalculates/0,
+         configuration_cached_wrong_simply_recalculates/1,
+         configuration_cached_wrong_without_password_fails/0,
+         configuration_cached_wrong_without_password_fails/1,
+         verification_name_escapes_values_correctly/1,
+         verification_name_does_not_escape_values_correctly/1,
+         authentication_server_last_message_is_an_error/1,
+         authentication_server_rejects_the_proof/1,
+         authentication_client_rejects_the_signature/1,
+         nonce_client_receives_invalid/1,
+         nonce_server_finds_non_matching/1,
+         channel_not_advertise_but_client_could_is_ok/1,
+         channel_binding_client_did_not_see_available_plus/1,
+         channel_server_offers_but_client_does_not_take_is_ok/1,
+         channel_type_does_not_match/1,
+         channel_type_matches_but_data_does_not/1,
+         channel_is_not_supported_by_the_server/1,
+         missing_username/1,
+         missing_authzid/1,
+         missing_gs2/1,
+         missing_gs2_info/1,
+         missing_nonce/1,
+         missing_salt/1,
+         missing_it_count/1,
+         missing_proof/1,
+         missing_proof_info/1,
+         missing_channel_binding/1,
+         missing_channel_binding_info/1,
+         wrong_flag_username/1,
+         wrong_flag_g2s/1,
+         wrong_flag_nonce/1,
+         wrong_flag_salt/1,
+         wrong_flag_it_count/1,
+         wrong_it_count/1,
+         too_much_input/1,
+         not_supported_authzid/1,
+         not_supported_mext/1,
+         not_supported_extension/1
+        ]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() ->
+    [
+     {group, verifications},
+     {group, authentication},
+     {group, nonce},
+     {group, channel},
+     {group, missing_flags},
+     {group, wrong_input},
+     {group, not_supported}
+    ].
+
+
+groups() ->
+    [
+     {verifications, [parallel],
+      [
+       regular_scram_authentication_example_from_the_rfc,
+       regular_scram_authentication,
+       wrong_configuration_key,
+       verification_name_escapes_values_correctly,
+       verification_name_does_not_escape_values_correctly,
+       configuration_client_sends_wrong_username,
+       configuration_cached_keys_works_easily,
+       configuration_cached_keys_works_easily_v2,
+       configuration_cached_wrong_simply_recalculates,
+       configuration_cached_wrong_without_password_fails
+      ]},
+     {authentication, [parallel],
+      [
+       authentication_server_last_message_is_an_error,
+       authentication_server_rejects_the_proof,
+       authentication_client_rejects_the_signature
+      ]},
+     {nonce, [parallel],
+      [
+       nonce_client_receives_invalid,
+       nonce_server_finds_non_matching
+      ]},
+     {channel, [parallel],
+      [
+       channel_not_advertise_but_client_could_is_ok,
+       channel_binding_client_did_not_see_available_plus,
+       channel_server_offers_but_client_does_not_take_is_ok,
+       channel_type_does_not_match,
+       channel_type_matches_but_data_does_not,
+       channel_is_not_supported_by_the_server
+      ]},
+     {missing_flags, [parallel],
+      [
+       missing_username,
+       missing_authzid,
+       missing_gs2,
+       missing_gs2_info,
+       missing_nonce,
+       missing_salt,
+       missing_it_count,
+       missing_proof,
+       missing_proof_info,
+       missing_channel_binding,
+       missing_channel_binding_info
+      ]},
+     {wrong_input, [],
+      [
+       wrong_flag_username,
+       wrong_flag_g2s,
+       wrong_flag_nonce,
+       wrong_flag_salt,
+       wrong_flag_it_count,
+       wrong_it_count,
+       too_much_input
+      ]},
+     {not_supported, [parallel],
+      [
+       not_supported_authzid,
+       not_supported_mext,
+       not_supported_extension
+      ]}
+    ].
+
+%%%===================================================================
+%%% Individual Test Cases (from groups() definition)
+%%%===================================================================
+regular_scram_authentication_example_from_the_rfc(_Config) ->
+    %% Client and Server have matching configurations
+    ClientState1 = typical_scram_configuration(client),
+    ServerState2 = typical_scram_configuration(server),
+    %% AUTH
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ?assertEqual(client_first(), ClientFirst),
+    %% CHALLENGE
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    ?assertEqual(server_first(), ServerFirst),
+    %% RESPONSE
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    ?assertEqual(client_final(), ClientFinal),
+    %% SUCCESS
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    ?assertEqual(server_final(), ServerFinal),
+    %% Client successfully accepts the server's verifier
+    {ok, _Final, _ClientState7} = fast_scram:mech_step(ClientState5, ServerFinal).
+
+regular_scram_authentication(_Config) ->
+    Password = base64:encode(crypto:strong_rand_bytes(8 + rand:uniform(8))),
+    {ok, ClientState1} = fast_scram:mech_new(#{entity => client,
+                                               hash_method => sha256,
+                                               username => <<"user">>,
+                                               auth_data => #{password => Password}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha256,
+                             username => <<"user">>,
+                             retrieve_mechanism =>
+                                 fun(U, S) -> retrieve_mechanism(U, #{password => Password}, S) end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    {ok, _Final, _ClientState7} = fast_scram:mech_step(ClientState5, ServerFinal).
+
+wrong_configuration_key(_Config) ->
+    {error, wrong_key, bad_key} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha256,
+                             username => <<"user">>,
+                             bad_key => any_value,
+                             auth_data => #{password => <<"pencil">>}}).
+
+configuration_cached_keys_works_easily() ->
+     [{timetrap,{seconds,1}}].
+
+configuration_cached_keys_works_easily(_Config) ->
+    Cached = cached_heavy_scram_definitions(),
+    {ok, ClientState1} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha,
+                             username => <<"user">>,
+                             cached_challenge => {base64:decode(<<"QSXCR+Q6sek8bf92">>), 409600000},
+                             auth_data => #{salted_password => Cached#scram_definitions.salted_password}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 409600000,
+                                           auth_data => #{
+                                             stored_key => Cached#scram_definitions.stored_key,
+                                             server_key => Cached#scram_definitions.server_key}}
+                                 end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    {ok, _Final, _ClientState7} = fast_scram:mech_step(ClientState5, ServerFinal).
+
+configuration_cached_keys_works_easily_v2() ->
+     [{timetrap,{seconds,1}}].
+
+configuration_cached_keys_works_easily_v2(_Config) ->
+    Cached = cached_heavy_scram_definitions(),
+    {ok, ClientState1} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha,
+                             username => <<"user">>,
+                             cached_challenge => {409600000, base64:decode(<<"QSXCR+Q6sek8bf92">>)},
+                             auth_data => #{
+                               client_key => Cached#scram_definitions.client_key,
+                               server_key => Cached#scram_definitions.server_key}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 409600000,
+                                           auth_data => #{
+                                             salted_password =>
+                                             Cached#scram_definitions.salted_password}}
+                                 end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    {ok, _Final, _ClientState7} = fast_scram:mech_step(ClientState5, ServerFinal).
+
+configuration_cached_wrong_simply_recalculates() ->
+     [{timetrap,{seconds,1}}].
+
+configuration_cached_wrong_simply_recalculates(_Config) ->
+    CachedRegular = cached_regular_scram_refinitions(),
+    CachedHeavy = cached_heavy_scram_definitions(),
+    {ok, ClientState1} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha,
+                             username => <<"user">>,
+                             cached_challenge => {409600000, base64:decode(<<"QSXCR+Q6sek8bf92">>)},
+                             auth_data => #{
+                               password => <<"pencil">>,
+                               salted_password => CachedHeavy#scram_definitions.salted_password}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{
+                                             password => <<"pencil">>,
+                                             stored_key => CachedRegular#scram_definitions.stored_key,
+                                             server_key =>
+                                             CachedRegular#scram_definitions.server_key}}
+                                 end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    {ok, _Final, _ClientState7} = fast_scram:mech_step(ClientState5, ServerFinal).
+
+configuration_cached_wrong_without_password_fails() ->
+     [{timetrap,{seconds,1}}].
+
+configuration_cached_wrong_without_password_fails(_Config) ->
+    CachedRegular = cached_regular_scram_refinitions(),
+    CachedHeavy = cached_heavy_scram_definitions(),
+    {ok, ClientState1} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha,
+                             username => <<"user">>,
+                             cached_challenge => {409600000, base64:decode(<<"QSXCR+Q6sek8bf92">>)},
+                             auth_data => #{
+                               salted_password => CachedHeavy#scram_definitions.salted_password}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{
+                                             password => <<"pencil">>,
+                                             stored_key => CachedRegular#scram_definitions.stored_key,
+                                             server_key =>
+                                             CachedRegular#scram_definitions.server_key}}
+                                 end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, _} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    ?assertEqual(<<"e=invalid-proof">>, Reason).
+
+authentication_server_rejects_the_proof(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    WrongProof = <<"c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,",
+                   "p=", (base64:encode(<<"wrong_proof">>))/binary>>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, WrongProof),
+    ?assertEqual(<<"e=invalid-proof">>, Reason).
+
+authentication_client_rejects_the_signature(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, _, ClientState5} = fast_scram:mech_step(ClientState3, server_first()),
+    WrongSignature = <<"v=", (base64:encode(<<"wrong_signature">>))/binary>>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState5, WrongSignature),
+    ?assertEqual(<<"authentication-failure">>, Reason).
+
+authentication_server_last_message_is_an_error(_Config) ->
+    ClientState = typical_scram_configuration(client),
+    {error, Reason, _} = fast_scram:mech_step(ClientState#fast_scram_state{step = 5}, <<"e=invalid">>),
+    ?assertEqual(<<"invalid">>, Reason).
+
+configuration_client_sends_wrong_username(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    ServerState0 = typical_scram_configuration(server),
+    ServerState2 = ServerState0#fast_scram_state{
+                     data = #{username => <<"not-user">>, password => <<"pencil">>}},
+    {continue, ClientFirst, _} = fast_scram:mech_step(ClientState1, <<>>),
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst),
+    ?assertEqual(<<"unknown-user">>, Reason).
+
+verification_name_escapes_values_correctly(_Config) ->
+    ServerState0 = #fast_scram_state{data = Data} = typical_scram_configuration(server),
+    ServerState2 = ServerState0#fast_scram_state{
+                     data = Data#{username => <<"u,ser">>, password => <<"pencil">>}},
+    Username = <<"n,,n=u=2Cser,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {NextStep, _, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(continue, NextStep).
+
+verification_name_does_not_escape_values_correctly(_Config) ->
+    ServerState0 = typical_scram_configuration(server),
+    ServerState2 = ServerState0#fast_scram_state{
+                     data = #{username => <<"u,ser">>, password => <<"pencil">>}},
+    Username = <<"n,,n=u=ser,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"invalid-username-encoding">>, Reason).
+
+%% The client MUST verify that the initial part of the nonce used in subsequent messages
+%% is the same as the nonce it initially specified
+nonce_client_receives_invalid(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongNonce = <<"r=clientreceiveswrongnonce3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongNonce),
+    ?assertEqual(<<"invalid-nonce">>, Reason).
+
+%% The server MUST verify that the nonce sent by the client in the second message
+%% is the same as the one sent by the server in its first message.
+nonce_server_finds_non_matching(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    WrongNonce = <<"c=biws,r=bad_nonce_FgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, WrongNonce),
+    ?assertEqual(<<"e=invalid-nonce">>, Reason).
+
+%% If the flag is set to "y" and the server supports channel binding,
+%% the server MUST fail authentication.
+%% This is because if the client sets the channel binding flag to "y",
+%% then the client must have believed that the server did not support channel binding
+%% -- if the server did in fact support channel binding,
+%% then this is an indication that there has been a downgrade attack
+%% (e.g., an attacker changed the server’s mechanism list to exclude the -PLUS
+%% suffixed SCRAM mechanism name(s)).
+channel_binding_client_did_not_see_available_plus(_Config) ->
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             channel_binding => {<<"tls-unique">>, <<1,2,3,4,5,6,7,8>>},
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{
+                                             password => <<"pencil">>}}
+                                 end}),
+    YesGS2Flag = <<"y,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, YesGS2Flag),
+    ?assertEqual(<<"server-does-support-channel-binding">>, Reason).
+
+channel_server_offers_but_client_does_not_take_is_ok(_Config) ->
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             channel_binding => {<<"tls-unique">>, <<1,2,3,4,5,6,7,8>>},
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{password => <<"pencil">>}}
+                                 end}),
+    YesGS2Flag = <<"n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {continue, _, _} = fast_scram:mech_step(ServerState2, YesGS2Flag).
+
+
+channel_not_advertise_but_client_could_is_ok(_Config) ->
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{password => <<"pencil">>}}
+                                 end}),
+    YesGS2Flag = <<"y,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {continue, _, _} = fast_scram:mech_step(ServerState2, YesGS2Flag).
+
+
+%% If the channel binding flag was "p" and the server does not support
+%% the indicated channel binding type, then the server MUST fail authentication.
+channel_type_does_not_match(_Config) ->
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             channel_binding => {<<"some_server_type">>, <<1,2,3,4,5,6,7,8>>},
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{password => <<"pencil">>}}
+                                 end}),
+    ClientFirst = <<"p=some_client_type,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst),
+    ?assertEqual(<<"unsupported-channel-binding-type">>, Reason).
+
+channel_type_matches_but_data_does_not(_Config) ->
+    {ok, ClientState1} = fast_scram:mech_new(
+                           #{entity => client,
+                             hash_method => sha,
+                             username => <<"user">>,
+                             channel_binding => {<<"tls-unique">>, <<1,2,3,4,5,6,7,8>>},
+                             auth_data => #{password => <<"pencil">>}}),
+    {ok, ServerState2} = fast_scram:mech_new(
+                           #{entity => server,
+                             hash_method => sha,
+                             channel_binding => {<<"tls-unique">>, <<2,2,3,4,5,6,7,8>>},
+                             retrieve_mechanism =>
+                                 fun(_) ->
+                                         #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+                                           it_count => 4096,
+                                           auth_data => #{password => <<"pencil">>}}
+                                 end}),
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, _} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    ?assertEqual(<<"e=channel-bindings-dont-match">>, Reason).
+
+channel_is_not_supported_by_the_server(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    ClientFirst = <<"p=tls-unique,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst),
+    ?assertEqual(<<"channel-binding-not-supported">>, Reason).
+
+missing_username(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,,,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"unknown-user">>, Reason).
+missing_authzid(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_gs2_info(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<",,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_gs2(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<",n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_nonce(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,,n=user,">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_salt(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongNonce = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,,i=4096">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongNonce),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_it_count(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongNonce = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongNonce),
+    ?assertEqual(<<"no-resources">>, Reason).
+missing_proof_info(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    WrongProof = <<"c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,">>,
+    {error, NoResources, _} = fast_scram:mech_step(ServerState4, WrongProof),
+    ?assertEqual(<<"e=other-error">>, NoResources),
+    EmptyProof = <<"c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=">>,
+    {error, InvalidProof, _} = fast_scram:mech_step(ServerState4, EmptyProof),
+    ?assertEqual(<<"e=invalid-proof">>, InvalidProof).
+missing_proof(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    WrongProof = <<"c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, WrongProof),
+    ?assertEqual(<<"e=other-error">>, Reason).
+missing_channel_binding_info(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    MissingCB = <<",r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, MissingCB),
+    ?assertEqual(<<"e=no-resources">>, Reason).
+missing_channel_binding(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, client_first()),
+    MissingCB = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState4, MissingCB),
+    ?assertEqual(<<"e=no-resources">>, Reason).
+
+wrong_flag_username(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,,wrong,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"other-error">>, Reason).
+wrong_flag_g2s(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"wrong,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"other-error">>, Reason).
+wrong_flag_nonce(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,,n=user,wrong">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"other-error">>, Reason).
+wrong_flag_salt(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongNonce = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,wrong,i=4096">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongNonce),
+    ?assertEqual(<<"other-error">>, Reason).
+wrong_flag_it_count(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongItCount = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,wrong">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongItCount),
+    ?assertEqual(<<"other-error">>, Reason).
+wrong_it_count(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWrongItCount = <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=wrong">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWrongItCount),
+    ?assertEqual(<<"invalid-iteration-count">>, Reason).
+too_much_input(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    Username = <<"n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL,r=toomuch">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, Username),
+    ?assertEqual(<<"error-too-much-input">>, Reason).
+
+
+not_supported_authzid(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    ClientFirst = <<"n,a=other_user,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst),
+    ?assertEqual(<<"authzid-flag-not-supported">>, Reason).
+not_supported_mext(_Config) ->
+    ClientState1 = typical_scram_configuration(client),
+    {continue, _, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    ServerWithMext = <<"m=mext,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096">>,
+    {error, Reason, _} = fast_scram:mech_step(ClientState3, ServerWithMext),
+    ?assertEqual(<<"extensions-not-supported">>, Reason).
+not_supported_extension(_Config) ->
+    ServerState2 = typical_scram_configuration(server),
+    ClientFirst1 = <<"n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL,t=extension">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst1),
+    ?assertEqual(<<"extensions-not-supported">>, Reason),
+    ClientFirst2 = <<"n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL,m=extension">>,
+    {error, Reason, _} = fast_scram:mech_step(ServerState2, ClientFirst2),
+    ?assertEqual(<<"extensions-not-supported">>, Reason).
+
+
+%%%===================================================================
+%%% Helper functions
+%%%===================================================================
+
+typical_scram_configuration(Entity) ->
+    typical_scram_configuration(Entity, #{password => <<"pencil">>}, #{}).
+
+typical_scram_configuration(client, AuthData, Other) ->
+    Config0 = #{entity => client,
+                hash_method => sha,
+                username => <<"user">>,
+                nonce => <<"fyko+d2lbbFgONRv9qkxdawL">>,
+                auth_data => AuthData},
+    Config1 = maps:merge(Config0, Other),
+    {ok, St} = fast_scram:mech_new(Config1),
+    St;
+typical_scram_configuration(server, AuthData, Other) ->
+    Config0 = #{entity => server,
+                hash_method => sha,
+                nonce => <<"3rfcNHYJY1ZVvWVs7j">>,
+                retrieve_mechanism => fun(U, S) -> retrieve_mechanism(U, AuthData, S) end},
+    Config1 = maps:merge(Config0, Other),
+    {ok, St} = fast_scram:mech_new(Config1),
+    St.
+
+retrieve_mechanism(_, AuthData, S) ->
+    X = #{salt => base64:decode(<<"QSXCR+Q6sek8bf92">>),
+      it_count => 4096,
+      auth_data => AuthData},
+    {X, S}.
+
+client_first() -> <<"n,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>.
+server_first() -> <<"r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096">>.
+client_final() -> <<"c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,p=v0X8v3Bz2T0CJGbJQyF0X+HI4Ts=">>.
+server_final() -> <<"v=rmF9pqV8S7suAoZWja4dJRkFsKQ=">>.
+
+%%% Precalculated with an iteration cout of 4096
+cached_regular_scram_refinitions() ->
+    #scram_definitions{
+       hash_method      = sha,
+       salted_password  = <<29,150,238,58,82,155,90,95,158,71,192,31,34,154,44,184,166,225,95,125>>,
+       client_key       = <<226,52,196,123,246,195,102,150,221,109,133,43,153,170,162,186,38,85,87,40>>,
+       stored_key       = <<233,217,70,96,195,157,101,195,143,186,217,28,53,143,20,218,14,239,43,214>>,
+       auth_message     = <<"n=user,r=fyko+d2lbbFgONRv9qkxdawL,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=4096,c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j">>,
+       client_signature = <<93,113,56,196,134,176,191,171,223,73,227,226,218,139,214,229,199,157,182,19>>,
+       client_proof     = <<191,69,252,191,112,115,217,61,2,36,102,201,67,33,116,95,225,200,225,59>>,
+       server_key       = <<15,224,146,88,179,172,133,43,165,2,204,98,186,144,62,170,205,191,125,49>>,
+       server_signature = <<174,97,125,166,165,124,75,187,46,2,134,86,141,174,29,37,25,5,176,164>>
+      }.
+
+%%% This was calculated for the same parameters than as above,
+%%% except that the iteration count is 409600000, so it would take a long time
+cached_heavy_scram_definitions() ->
+    #scram_definitions{
+       hash_method      = sha,
+       salted_password  = <<88,214,221,58,163,214,103,20,235,222,209,209,41,158,166,159,61,23,116,62>>,
+       client_key       = <<30,240,57,94,35,56,109,230,129,154,73,94,142,182,50,156,78,128,171,29>>,
+       stored_key       = <<31,45,16,146,4,98,92,24,40,167,241,234,95,61,79,194,127,194,197,103>>,
+       auth_message     = <<"n=user,r=fyko+d2lbbFgONRv9qkxdawL,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j,s=QSXCR+Q6sek8bf92,i=409600000,c=biws,r=fyko+d2lbbFgONRv9qkxdawL3rfcNHYJY1ZVvWVs7j">>,
+       client_signature = <<209,237,202,96,155,147,96,108,48,218,110,140,122,223,86,215,92,171,193,19>>,
+       client_proof     = <<207,29,243,62,184,171,13,138,177,64,39,210,244,105,100,75,18,43,106,14>>,
+       server_key       = <<222,94,85,104,169,47,131,128,114,6,162,90,225,108,19,88,133,210,62,187>>,
+       server_signature = <<87,156,101,76,203,139,198,161,160,20,24,9,165,245,125,35,171,138,16,195>>
+      }.


### PR DESCRIPTION
So, this is a work I did a long time ago, in the early summer, that further ahead I've been just trying to rewrite the git history to help making it more reviewable, but no code changes have been introduced ever since. And as October is ending, I just thought it could throw this for the **_hacktoberfest_** 😄

How does it work, it is explained in the README as best as I could. How would it look to use it?
Here's a WIP for escalus: https://github.com/esl/escalus/pull/235, which is the simplest version
Here's a WIP for MIM: https://github.com/esl/MongooseIM/compare/master...NelsonVides:scram

One thing I didn't do here is that SCRAM requires user and password to have passed the stringprepping algorithm, but I thought that introducing a stringprepping library as a dependency to this repository would be a bit of a dependency hell, so perhaps it could be a library requirement that these parameters were already stringprepped before being passed here. But I'm not sure about it, perhaps the stringprepping library can be included nevertheless. Looking for opinions.