### PR TITLE
Introduce block counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Building is as easy as `rebar3 compile`, and using it in your projects as
 
 
 ## Using
+### SCRAM
 In SCRAM, a `SaltedPassword` is defined as
 ```
 SaltedPassword := Hi(Normalize(password), salt, i)
@@ -37,6 +38,15 @@ where `Hash` is the underlying hash function chosen as described by
 ```erlang
 -type sha_type() :: crypto:sha1() | crypto:sha2().
 ```
+
+### PBKDF2
+If what you desire is PBKDF2 (I assume that if that is what you want, then you know your RFC), in a
+way that allows you to request longer derived keys, you may use `fast_scram:pbkdf2_block/5` with a
+given block index and do the indexing and chunking yourself, or use `fast_scram:pbkdf2/5` for the
+full algorithm. However, it doesn't really add much more entropy to the derived key to use outputs
+larger than the output of the underlying hash, so you might as well, use `pbkdf2` where dkLen is
+that of the hash's output, which is the same than `pbkdf2_block` with index `1`, which is simply the
+`hi` function.
 
 ### Full algorithm
 If you want to avoid reimplementing SCRAM again and again, you can use the extended API.

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,8 @@
   {test, [
     {deps, [
       {statistics, {git, "https://github.com/NelsonVides/statistics.git", {branch, "master"}}},
-      {proper, "1.3.0"}
+      {proper, "1.3.0"},
+      {base16, {git, "https://github.com/esl/base16.git", {tag, "1.1.0"}}}
      ]},
     {plugins, [
        {rebar3_codecov, {git, "https://github.com/esl/rebar3_codecov.git", {ref, "6bd31cc"}}}

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -16,7 +16,7 @@
     {continue,  next_message(), fast_scram_state()} |
     {error,    error_message(), fast_scram_state()}.
 
--export([hi/4]).
+-export([hi/4, pbkdf2_block/5]).
 
 -export([mech_new/1,
          mech_step/2
@@ -332,7 +332,11 @@ server_signature(Sha, ServerKey, AuthMessage) ->
 %%% NIF
 %%%===================================================================
 -spec hi(sha_type(), binary(), binary(), non_neg_integer()) -> binary().
-hi(_Hash, _Password, _Salt, _IterationCount) ->
+hi(Hash, Password, Salt, IterationCount) ->
+    pbkdf2_block(Hash, Password, Salt, IterationCount, 1).
+
+-spec pbkdf2_block(sha_type(), binary(), binary(), non_neg_integer(), non_neg_integer()) -> binary().
+pbkdf2_block(_Hash, _Password, _Salt, _IterationCount, _BlockSize) ->
     erlang:nif_error(not_loaded).
 
 -spec load() -> any().

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -16,7 +16,7 @@
     {continue,  next_message(), fast_scram_state()} |
     {error,    error_message(), fast_scram_state()}.
 
--export([hi/4, pbkdf2_block/5]).
+-export([hi/4, pbkdf2_block/5, pbkdf2/5]).
 
 -export([mech_new/1,
          mech_step/2
@@ -338,6 +338,17 @@ hi(Hash, Password, Salt, IterationCount) ->
 -spec pbkdf2_block(sha_type(), binary(), binary(), non_neg_integer(), non_neg_integer()) -> binary().
 pbkdf2_block(_Hash, _Password, _Salt, _IterationCount, _BlockSize) ->
     erlang:nif_error(not_loaded).
+
+-spec pbkdf2(sha_type(), binary(), binary(), non_neg_integer(), non_neg_integer()) -> binary().
+pbkdf2(Hash, Password, Salt, IterationCount, DkLen) ->
+    pbkdf2(Hash, Password, Salt, IterationCount, DkLen, 1, [], 0).
+
+pbkdf2(_Hash, _Password, _Salt, _IterationCount, DkLen, _BlockIndex, Acc, Len) when Len >= DkLen ->
+    Bin = iolist_to_binary(lists:reverse(Acc)),
+    binary:part(Bin, 0, DkLen);
+pbkdf2(Hash, Password, Salt, IterationCount, DkLen, BlockIndex, Acc, Len) ->
+    Block = pbkdf2_block(Hash, Password, Salt, IterationCount, BlockIndex),
+    pbkdf2(Hash, Password, Salt, IterationCount, DkLen, BlockIndex + 1, [Block | Acc], byte_size(Block) + Len).
 
 -spec load() -> any().
 load() ->

--- a/test/pbkdf2_SUITE.erl
+++ b/test/pbkdf2_SUITE.erl
@@ -19,6 +19,19 @@
          erlang_and_nif_are_equivalent_sha512/1,
          realtime_test/1
         ]).
+-export([
+         test_vector_sha1_1/1,
+         test_vector_sha1_2/1,
+         test_vector_sha1_3/1,
+         test_vector_sha1_4/1,
+         test_vector_sha1_5/1,
+         test_vector_sha256_1/1,
+         test_vector_sha256_2/1,
+         test_vector_sha256_3/1,
+         test_vector_sha256_4/1,
+         test_vector_sha256_5/1,
+         test_vector_sha256_6/1
+        ]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("proper/include/proper.hrl").
@@ -27,6 +40,7 @@
 all() ->
     [
      {group, equivalents},
+     {group, test_vectors},
      realtime_test
     ].
 
@@ -39,6 +53,20 @@ groups() ->
        erlang_and_nif_are_equivalent_sha256,
        erlang_and_nif_are_equivalent_sha384,
        erlang_and_nif_are_equivalent_sha512
+      ]},
+     {test_vectors, [parallel],
+      [
+       test_vector_sha1_1,
+       test_vector_sha1_2,
+       test_vector_sha1_3,
+       test_vector_sha1_4,
+       test_vector_sha1_5,
+       test_vector_sha256_1,
+       test_vector_sha256_2,
+       test_vector_sha256_3,
+       test_vector_sha256_4,
+       test_vector_sha256_5,
+       test_vector_sha256_6
       ]}
     ].
 
@@ -98,6 +126,67 @@ erlang_and_nif_are_equivalent_(Sha) ->
                                      {numtests, 100},
                                      {start_size, 2},
                                      {max_size, 64}])).
+
+
+%% Taken from the official RFC https://www.ietf.org/rfc/rfc6070.txt
+
+test_vector_sha1_1(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>,<<"salt">>,1,20,
+     base16:decode(<<"0c60c80f961f0e71f3a9b524af6012062fe037a6">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha, P, S, It, DkLen)).
+
+test_vector_sha1_2(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>,<<"salt">>,2,20,
+     base16:decode(<<"ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha, P, S, It, DkLen)).
+
+test_vector_sha1_3(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>,<<"salt">>,4096,20,
+     base16:decode(<<"4b007901b765489abead49d926f721d065a429c1">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha, P, S, It, DkLen)).
+
+test_vector_sha1_4(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>,<<"salt">>,16777216,20,
+     base16:decode(<<"eefe3d61cd4da4e4e9945b3d6ba2158c2634e984">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha, P, S, It, DkLen)).
+
+test_vector_sha1_5(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"passwordPASSWORDpassword">>,<<"saltSALTsaltSALTsaltSALTsaltSALTsalt">>,4096,25,
+     base16:decode(<<"3d2eec4fe41c849b80c8d83662c0e44a8b291a964cf2f07038">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha, P, S, It, DkLen)).
+
+
+%% Taken from https://stackoverflow.com/a/5136918/8853275
+test_vector_sha256_1(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>, <<"salt">>, 1, 32,
+     base16:decode(<<"120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
+test_vector_sha256_2(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>, <<"salt">>, 2, 32,
+     base16:decode(<<"ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
+test_vector_sha256_3(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>, <<"salt">>, 4096, 32,
+     base16:decode(<<"c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
+test_vector_sha256_4(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"password">>, <<"salt">>, 16777216, 32,
+     base16:decode(<<"cf81c66fe8cfc04d1f31ecb65dab4089f7f179e89b3b0bcb17ad10e3ac6eba46">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
+test_vector_sha256_5(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"passwordPASSWORDpassword">>,<<"saltSALTsaltSALTsaltSALTsaltSALTsalt">>,4096,40,
+      base16:decode(<<"348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c4e2a1fb8dd53e1c635518c7dac47e9">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
+test_vector_sha256_6(_Config) ->
+    {P,S,It,DkLen,Result} = {<<"pass\0word">>, <<"sa\0lt">>, 4096, 16,
+     base16:decode(<<"89b69d0516f829893c696226650a8687">>)},
+    ?assertEqual(Result, fast_scram:pbkdf2(sha256, P, S, It, DkLen)).
+
 
 -ifdef(STATISTICS).
 realtime_test(_Config) ->


### PR DESCRIPTION
This will be good when requesting other repositories who have tried to implement pbkdf2 the erlang way. Nobody should be using blocks bigger than that of the underlying hash function, but in case someone does, they might take the effort to implement the accumulation and truncation in erlang while still taking advantage of the looping in the main nif.

Read commit message, with the RFC specification, below:

PBKDF2, even if it's not necessarily a good idea, allows to extend the
derived key for as long as it's desired. So to be compatible, let's
follow the RFC to the detail. This way, from the erlang level, blocks
can be built and glued and truncated as desired, while the iterations
are still running on the main nif.

5.2 PBKDF2

   PBKDF2 applies a pseudorandom function (see Appendix B.1 for an
   example) to derive keys. The length of the derived key is essentially
   unbounded. (However, the maximum effective search space for the
   derived key may be limited by the structure of the underlying
   pseudorandom function. See Appendix B.1 for further discussion.)
   PBKDF2 is recommended for new applications.

   PBKDF2 (P, S, c, dkLen)

   Options:        PRF        underlying pseudorandom function (hLen
                              denotes the length in octets of the
                              pseudorandom function output)

   Input:          P          password, an octet string
                   S          salt, an octet string
                   c          iteration count, a positive integer
                   dkLen      intended length in octets of the derived
                              key, a positive integer, at most
                              (2^32 - 1) * hLen

   Output:         DK         derived key, a dkLen-octet string

   Steps:

      1. If dkLen > (2^32 - 1) * hLen, output "derived key too long" and
         stop.

      2. Let l be the number of hLen-octet blocks in the derived key,
         rounding up, and let r be the number of octets in the last
         block:

                   l = CEIL (dkLen / hLen) ,
                   r = dkLen - (l - 1) * hLen .

         Here, CEIL (x) is the "ceiling" function, i.e. the smallest
         integer greater than, or equal to, x.

      3. For each block of the derived key apply the function F defined
         below to the password P, the salt S, the iteration count c, and
         the block index to compute the block:

                   T_1 = F (P, S, c, 1) ,
                   T_2 = F (P, S, c, 2) ,
                   ...
                   T_l = F (P, S, c, l) ,

         where the function F is defined as the exclusive-or sum of the
         first c iterates of the underlying pseudorandom function PRF
         applied to the password P and the concatenation of the salt S
         and the block index i:

                   F (P, S, c, i) = U_1 \xor U_2 \xor ... \xor U_c
         where
                   U_1 = PRF (P, S || INT (i)) ,
                   U_2 = PRF (P, U_1) ,
                   ...
                   U_c = PRF (P, U_{c-1}) .

         Here, INT (i) is a four-octet encoding of the integer i, most
         significant octet first.

      4. Concatenate the blocks and extract the first dkLen octets to
         produce a derived key DK:

                   DK = T_1 || T_2 ||  ...  || T_l<0..r-1>

      5. Output the derived key DK.

   Note. The construction of the function F follows a "belt-and-
   suspenders" approach. The iterates U_i are computed recursively to
   remove a degree of parallelism from an opponent; they are exclusive-
   ored together to reduce concerns about the recursion degenerating
   into a small set of values.