### PR TITLE
Fix mac

### DIFF
--- a/src/fast_scram_definitions.erl
+++ b/src/fast_scram_definitions.erl
@@ -66,7 +66,7 @@ server_signature(Sha, ServerKey, AuthMessage)
   when ?is_valid_hash(Sha), is_binary(ServerKey), is_binary(AuthMessage) ->
     crypto_hmac(Sha, ServerKey, AuthMessage).
 
--if(?OTP_RELEASE >= 22).
+-if(?OTP_RELEASE >= 23).
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:mac(hmac, Sha, Bin1, Bin2).
 -else.

--- a/src/fast_scram_definitions.erl
+++ b/src/fast_scram_definitions.erl
@@ -66,9 +66,14 @@ server_signature(Sha, ServerKey, AuthMessage)
   when ?is_valid_hash(Sha), is_binary(ServerKey), is_binary(AuthMessage) ->
     crypto_hmac(Sha, ServerKey, AuthMessage).
 
+-ifdef(OTP_RELEASE).
 -if(?OTP_RELEASE >= 23).
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:mac(hmac, Sha, Bin1, Bin2).
+-else.
+crypto_hmac(Sha, Bin1, Bin2) ->
+    crypto:hmac(Sha, Bin1, Bin2).
+-endif.
 -else.
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:hmac(Sha, Bin1, Bin2).

--- a/test/erlang_scram.erl
+++ b/test/erlang_scram.erl
@@ -27,7 +27,7 @@ mask(Key, Data) ->
     C = A bxor B,
     <<C:KeySize>>.
 
--if(?OTP_RELEASE >= 22).
+-if(?OTP_RELEASE >= 23).
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:mac(hmac, Sha, Bin1, Bin2).
 -else.

--- a/test/erlang_scram.erl
+++ b/test/erlang_scram.erl
@@ -27,9 +27,14 @@ mask(Key, Data) ->
     C = A bxor B,
     <<C:KeySize>>.
 
+-ifdef(OTP_RELEASE).
 -if(?OTP_RELEASE >= 23).
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:mac(hmac, Sha, Bin1, Bin2).
+-else.
+crypto_hmac(Sha, Bin1, Bin2) ->
+    crypto:hmac(Sha, Bin1, Bin2).
+-endif.
 -else.
 crypto_hmac(Sha, Bin1, Bin2) ->
     crypto:hmac(Sha, Bin1, Bin2).


### PR DESCRIPTION
This change is made to ensure fast_scram will not fail on OTP 22.0 because `crypto:mac` was actually added in OTP 22.1. Because of that the code would fail for OTP 22.0 with `undef`. This PR addresses that and checks for the next major OTP version instead. Also it checks whether `?OTP_RELEASE` is available at all - it was added for OTP 21. If we think we don't want to support older OTP versions than this change can be omitted.