### PR TITLE
remove fast_pbkdf2 dependency

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, []}.
 
-{deps, [{fast_pbkdf2, "1.0.3"}]}.
+{deps, []}.
 {plugins, [rebar3_hex]}.
 
 {profiles, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,1 @@
-{"1.2.0",
-[{<<"fast_pbkdf2">>,{pkg,<<"fast_pbkdf2">>,<<"1.0.3">>},0}]}.
-[
-{pkg_hash,[
- {<<"fast_pbkdf2">>, <<"4F09D6C6C20DBEE1970E0A6AE91432E1B7731F88426C671D083BAC31FFA1FDAD">>}]},
-{pkg_hash_ext,[
- {<<"fast_pbkdf2">>, <<"2900431E2E6402F23A92754448BBD949DA366BC9C984FDC791DDCFCC41042434">>}]}
-].
+[].

--- a/src/fast_scram.erl
+++ b/src/fast_scram.erl
@@ -333,4 +333,5 @@ server_signature(Sha, ServerKey, AuthMessage) ->
 -spec hi(sha_type(), binary(), binary(), non_neg_integer()) -> binary().
 hi(Hash, Password, Salt, IterationCount)
   when ?is_valid_hash(Hash), is_binary(Password), is_binary(Salt), ?is_positive_integer(IterationCount) ->
-    fast_pbkdf2:pbkdf2(Hash, Password, Salt, IterationCount).
+    #{ size := KeyLength } = crypto:hash_info(Hash),
+    crypto:pbkdf2_hmac(Hash, Password, Salt, IterationCount, KeyLength).

--- a/src/fast_scram_definitions.erl
+++ b/src/fast_scram_definitions.erl
@@ -34,7 +34,8 @@
 -spec salted_password(sha_type(), binary(), binary(), non_neg_integer()) -> binary().
 salted_password(Sha, Password, Salt, IterationCount)
   when ?is_valid_hash(Sha), is_binary(Password), is_binary(Salt), ?is_positive_integer(IterationCount) ->
-    fast_pbkdf2:pbkdf2(Sha, Password, Salt, IterationCount).
+    #{ size := KeyLength } = crypto:hash_info(Sha),
+    crypto:pbkdf2_hmac(Sha, Password, Salt, IterationCount, KeyLength). 
 
 -spec client_key(sha_type(), binary()) -> binary().
 client_key(Sha, SaltedPassword)


### PR DESCRIPTION
This PR remove the usage of fast_pbldf2 by using latest crypto API in Erlang. If needed i will add some legacy support for fast_pbkdf2. Or should it be an option?

I did remove this library because any libray based on openssl is hard to to deploy in multiple environnement, and I don't think  the performance s lower with this change though I didn't measure it precisely first. 