### PR TITLE
Fix server-side channel binding verification for y GS2 flag

### DIFF
--- a/src/fast_scram_parse_rules.erl
+++ b/src/fast_scram_parse_rules.erl
@@ -245,7 +245,7 @@ supported_channel_binding_flag(
     <<"y">>,
     #channel_binding{variant = undefined} = CbConfig
 ) ->
-    CbConfig;
+    CbConfig#channel_binding{variant = none};
 supported_channel_binding_flag(
     <<"y">>,
     #channel_binding{variant = Type}

--- a/test/scram_SUITE.erl
+++ b/test/scram_SUITE.erl
@@ -504,6 +504,15 @@ channel_server_offers_but_client_does_not_take_is_ok(_Config) ->
     {continue, _, _} = fast_scram:mech_step(ServerState2, YesGS2Flag).
 
 channel_not_advertise_but_client_could_is_ok(_Config) ->
+    {ok, ClientState1} = fast_scram:mech_new(
+        #{
+            entity => client,
+            hash_method => sha,
+            username => <<"user">>,
+            channel_binding => {none, <<>>},
+            auth_data => #{password => <<"pencil">>}
+        }
+    ),
     {ok, ServerState2} = fast_scram:mech_new(
         #{
             entity => server,
@@ -518,8 +527,11 @@ channel_not_advertise_but_client_could_is_ok(_Config) ->
                 end
         }
     ),
-    YesGS2Flag = <<"y,,n=user,r=fyko+d2lbbFgONRv9qkxdawL">>,
-    {continue, _, _} = fast_scram:mech_step(ServerState2, YesGS2Flag).
+    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
+    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
+    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
+    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
+    {ok, _, _} = fast_scram:mech_step(ClientState5, ServerFinal).
 
 %% If the channel binding flag was "p" and the server does not support
 %% the indicated channel binding type, then the server MUST fail authentication.


### PR DESCRIPTION
Server returned e=channel-bindings-dont-match when server does not support CB but client does.