### PR TITLE
Bump fast_pbkdf2 to 2.0.1

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,8 @@
 {"1.2.0",
-[{<<"fast_pbkdf2">>,{pkg,<<"fast_pbkdf2">>,<<"2.0.0">>},0}]}.
+[{<<"fast_pbkdf2">>,{pkg,<<"fast_pbkdf2">>,<<"2.0.1">>},0}]}.
 [
 {pkg_hash,[
- {<<"fast_pbkdf2">>, <<"72CDEE3C10C6B9B40E31194DE946A883CEEF6CF1F37D7FC9FD1A9D87502723F5">>}]},
+ {<<"fast_pbkdf2">>, <<"DD4A9A57F58CF783050F041C6316BE0B91545487DD1E30FBEB9A65785163A3FD">>}]},
 {pkg_hash_ext,[
- {<<"fast_pbkdf2">>, <<"74159FD09FB8BF5E97D25137C6C83C28E2CF7E97D7C127D83310DFD0904BD732">>}]}
+ {<<"fast_pbkdf2">>, <<"9409A316534EFA7873C30C2E106717AEE61EC6C93E963A66BC65FCFAE5B4C398">>}]}
 ].

--- a/test/scram_SUITE.erl
+++ b/test/scram_SUITE.erl
@@ -504,19 +504,11 @@ channel_server_offers_but_client_does_not_take_is_ok(_Config) ->
     {continue, _, _} = fast_scram:mech_step(ServerState2, YesGS2Flag).
 
 channel_not_advertise_but_client_could_is_ok(_Config) ->
-    {ok, ClientState1} = fast_scram:mech_new(
-        #{
-            entity => client,
-            hash_method => sha,
-            username => <<"user">>,
-            channel_binding => {none, <<>>},
-            auth_data => #{password => <<"pencil">>}
-        }
-    ),
     {ok, ServerState2} = fast_scram:mech_new(
         #{
             entity => server,
             hash_method => sha,
+            nonce => <<"fyko+d2lbbFgONRv9qkxdawL">>,
             retrieve_mechanism =>
                 fun(_) ->
                     #{
@@ -527,11 +519,11 @@ channel_not_advertise_but_client_could_is_ok(_Config) ->
                 end
         }
     ),
-    {continue, ClientFirst, ClientState3} = fast_scram:mech_step(ClientState1, <<>>),
-    {continue, ServerFirst, ServerState4} = fast_scram:mech_step(ServerState2, ClientFirst),
-    {continue, ClientFinal, ClientState5} = fast_scram:mech_step(ClientState3, ServerFirst),
-    {ok, ServerFinal, _} = fast_scram:mech_step(ServerState4, ClientFinal),
-    {ok, _, _} = fast_scram:mech_step(ClientState5, ServerFinal).
+    YesGS2Flag = <<"y,,n=user,r=lmGaEB+ze/7giz6VC6KEOw==">>,
+    {continue, _, ServerState4} = fast_scram:mech_step(ServerState2, YesGS2Flag),
+    ClientFinal =
+        <<"c=eSws,r=lmGaEB+ze/7giz6VC6KEOw==fyko+d2lbbFgONRv9qkxdawL,p=Ab1g6yKcTC3ay2KCQFkjDXdkYak=">>,
+    {ok, _, _} = fast_scram:mech_step(ServerState4, ClientFinal).
 
 %% If the channel binding flag was "p" and the server does not support
 %% the indicated channel binding type, then the server MUST fail authentication.


### PR DESCRIPTION
This PR includes the following changes:

- Bump fast_pbkdf2 to 2.0.1
- Simplify the common test added in #18: I removed the client state and replaced it with hardcoded messages to keep this test consistent with the others in this group. 
